### PR TITLE
feature(#11): create Flyway migration for template tables and update …

### DIFF
--- a/backend/brain/src/main/resources/db/migration/V2__create_template_tables.sql
+++ b/backend/brain/src/main/resources/db/migration/V2__create_template_tables.sql
@@ -1,0 +1,29 @@
+CREATE TABLE templates (
+    id BINARY(16) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    type VARCHAR(32) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    created_by BINARY(16) NOT NULL,
+    CONSTRAINT pk_templates PRIMARY KEY (id),
+    CONSTRAINT uq_templates_name UNIQUE (name)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE template_versions (
+    id BINARY(16) NOT NULL,
+    template_id BINARY(16) NOT NULL,
+    version VARCHAR(255) NOT NULL,
+    checksum VARCHAR(255) NOT NULL,
+    s3_key VARCHAR(255) NOT NULL,
+    metadata_json TEXT NULL,
+    created_at DATETIME(6) NOT NULL,
+    CONSTRAINT pk_template_versions PRIMARY KEY (id),
+    CONSTRAINT uq_template_versions_template_version UNIQUE (template_id, version),
+    CONSTRAINT fk_template_versions_template FOREIGN KEY (template_id) REFERENCES templates (id) ON DELETE CASCADE
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_template_versions_template_id ON template_versions (template_id);

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/repository/TemplateRepositoryTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/repository/TemplateRepositoryTest.java
@@ -20,7 +20,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class TemplateRepositoryTest {
 
@@ -33,7 +33,6 @@ class TemplateRepositoryTest {
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
-        registry.add("spring.flyway.enabled", () -> false);
     }
 
     @Autowired


### PR DESCRIPTION
- Added `V2__create_template_tables.sql` for `templates` and `template_versions` schema.
- Updated `TemplateRepositoryTest` to use `ddl-auto=validate` and enable Flyway migrations.

## Description
create Flyway migration for template tables and update RepositoryTest configurations

## Linked Issues
Closes #11

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
