### PR TITLE
feature(#15): refine `nodes` table schema and update documentation

### DIFF
--- a/backend/brain/src/main/resources/db/migration/V4__refine_nodes_table.sql
+++ b/backend/brain/src/main/resources/db/migration/V4__refine_nodes_table.sql
@@ -1,0 +1,16 @@
+ALTER TABLE nodes
+    MODIFY name VARCHAR(255) NOT NULL,
+    MODIFY region VARCHAR(255) NOT NULL,
+    MODIFY status VARCHAR(32) NOT NULL,
+    MODIFY dev_mode TINYINT(1) NOT NULL DEFAULT 0,
+    MODIFY capacity_slots INT NOT NULL,
+    MODIFY used_slots INT NOT NULL DEFAULT 0,
+    MODIFY last_heartbeat_at DATETIME(6) NOT NULL,
+    MODIFY node_version VARCHAR(64) NOT NULL DEFAULT 'unknown',
+    MODIFY tags TEXT NULL;
+
+ALTER TABLE nodes
+    ADD CONSTRAINT chk_nodes_status CHECK (status IN ('ONLINE', 'OFFLINE', 'UNKNOWN'));
+
+CREATE INDEX idx_nodes_status ON nodes (status);
+CREATE INDEX idx_nodes_region ON nodes (region);

--- a/docs/brain-specs.md
+++ b/docs/brain-specs.md
@@ -129,6 +129,11 @@ Entity:
     * `nodeVersion` (agent version string, set on registration / upgrade)
     * `authId` or `authTokenId` (for node authentication linkage)
 
+Persistence notes:
+
+* `nodes` table enforces unique `name`, with indexes on `status` and `region` for filtering.
+* `status` values are constrained to the defined enum set (`ONLINE`, `OFFLINE`, `UNKNOWN`).
+
 Plus a `NodeHeartbeat` log table if you want history; or just store last values on Node.
 
 ---


### PR DESCRIPTION
- Updated `nodes` table with stricter constraints, defaults, and new indexes (`status`, `region`).
- Added `CHECK` constraint for `status` field to enforce predefined values.
- Documented schema changes and persistence notes in `brain-specs.md`.

## Description
refine `nodes` table schema and update documentation

## Linked Issues
Closes #15

## Checklist
- [x] Code is complete
- [x] Tests updated if needed
- [x] No unrelated changes
- [x] Ready for review
