### PR TITLE
feature(#16): add node base URL support and default heartbeat configu…

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/BrainApplication.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/BrainApplication.java
@@ -1,8 +1,12 @@
 package net.spookly.kodama.brain;
+
+import net.spookly.kodama.brain.config.NodeProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(NodeProperties.class)
 public class BrainApplication {
 
     public static void main(String[] args) {

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/config/NodeProperties.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/config/NodeProperties.java
@@ -1,0 +1,21 @@
+package net.spookly.kodama.brain.config;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "node")
+public class NodeProperties {
+
+    @Min(1)
+    private int heartbeatIntervalSeconds = 30;
+
+    public int getHeartbeatIntervalSeconds() {
+        return heartbeatIntervalSeconds;
+    }
+
+    public void setHeartbeatIntervalSeconds(int heartbeatIntervalSeconds) {
+        this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+    }
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import jakarta.validation.Valid;
 import net.spookly.kodama.brain.dto.NodeDto;
 import net.spookly.kodama.brain.dto.NodeRegistrationRequest;
+import net.spookly.kodama.brain.dto.NodeRegistrationResponse;
 import net.spookly.kodama.brain.service.NodeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,9 +30,9 @@ public class NodeController {
         return nodeService.listNodes();
     }
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public NodeDto registerNode(@Valid @RequestBody NodeRegistrationRequest request) {
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.OK)
+    public NodeRegistrationResponse registerNode(@Valid @RequestBody NodeRegistrationRequest request) {
         return nodeService.registerNode(request);
     }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/node/Node.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/node/Node.java
@@ -57,6 +57,9 @@ public class Node {
     @Column(name = "tags", columnDefinition = "TEXT")
     private String tags;
 
+    @Column(name = "base_url", length = 512)
+    private String baseUrl;
+
     public Node(
             String name,
             String region,
@@ -66,7 +69,8 @@ public class Node {
             int usedSlots,
             OffsetDateTime lastHeartbeatAt,
             String nodeVersion,
-            String tags) {
+            String tags,
+            String baseUrl) {
         validateSlotCounts(capacitySlots, usedSlots);
         this.name = Objects.requireNonNull(name, "name");
         this.region = Objects.requireNonNull(region, "region");
@@ -77,6 +81,7 @@ public class Node {
         this.lastHeartbeatAt = Objects.requireNonNull(lastHeartbeatAt, "lastHeartbeatAt");
         this.nodeVersion = Objects.requireNonNull(nodeVersion, "nodeVersion");
         this.tags = tags;
+        this.baseUrl = baseUrl;
     }
 
     public void updateRegistration(
@@ -85,13 +90,15 @@ public class Node {
             int capacitySlots,
             String nodeVersion,
             String tags,
-            NodeStatus status) {
+            NodeStatus status,
+            String baseUrl) {
         validateSlotCounts(capacitySlots, usedSlots);
         this.region = Objects.requireNonNull(region, "region");
         this.devMode = devMode;
         this.capacitySlots = capacitySlots;
         this.nodeVersion = Objects.requireNonNull(nodeVersion, "nodeVersion");
         this.tags = tags;
+        this.baseUrl = baseUrl;
         if (status != null) {
             this.status = status;
         }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeDto.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeDto.java
@@ -24,6 +24,7 @@ public class NodeDto {
     private OffsetDateTime lastHeartbeatAt;
     private String nodeVersion;
     private String tags;
+    private String baseUrl;
 
     public static NodeDto fromEntity(Node node) {
         return new NodeDto(
@@ -36,7 +37,8 @@ public class NodeDto {
                 node.getUsedSlots(),
                 node.getLastHeartbeatAt(),
                 node.getNodeVersion(),
-                node.getTags()
+                node.getTags(),
+                node.getBaseUrl()
         );
     }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeRegistrationRequest.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeRegistrationRequest.java
@@ -2,8 +2,11 @@ package net.spookly.kodama.brain.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import net.spookly.kodama.brain.domain.node.NodeStatus;
 
 @Getter
@@ -18,9 +21,6 @@ public class NodeRegistrationRequest {
     @NotBlank
     private String region;
 
-    @NotNull
-    private NodeStatus status;
-
     @Min(1)
     private int capacitySlots;
 
@@ -30,4 +30,9 @@ public class NodeRegistrationRequest {
     private boolean devMode;
 
     private String tags;
+
+    @Size(max = 512)
+    private String baseUrl;
+
+    private NodeStatus status = NodeStatus.ONLINE;
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeRegistrationResponse.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/NodeRegistrationResponse.java
@@ -1,0 +1,16 @@
+package net.spookly.kodama.brain.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class NodeRegistrationResponse {
+
+    private UUID nodeId;
+    private int heartbeatIntervalSeconds;
+}

--- a/backend/brain/src/main/resources/application.yml
+++ b/backend/brain/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
     enabled: true
     locations: ${SPRING_FLYWAY_LOCATIONS:classpath:db/migration}
 
+node:
+  heartbeat-interval-seconds: ${NODE_HEARTBEAT_INTERVAL_SECONDS:30}
+
 
 server:
   port: 8080

--- a/backend/brain/src/main/resources/db/migration/V5__add_node_base_url.sql
+++ b/backend/brain/src/main/resources/db/migration/V5__add_node_base_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE nodes
+    ADD COLUMN base_url VARCHAR(512) NULL AFTER tags;

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/repository/NodeRepositoryTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/repository/NodeRepositoryTest.java
@@ -50,7 +50,8 @@ class NodeRepositoryTest {
                 4,
                 heartbeat,
                 "1.2.3",
-                "primary,ssd"
+                "primary,ssd",
+                "http://node-1.internal"
         );
 
         Node saved = nodeRepository.save(node);
@@ -65,5 +66,6 @@ class NodeRepositoryTest {
         assertThat(persisted.getLastHeartbeatAt().toInstant()).isEqualTo(heartbeat.toInstant());
         assertThat(persisted.getNodeVersion()).isEqualTo("1.2.3");
         assertThat(persisted.getTags()).contains("primary");
+        assertThat(persisted.getBaseUrl()).isEqualTo("http://node-1.internal");
     }
 }

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/NodeServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/NodeServiceTest.java
@@ -1,0 +1,117 @@
+package net.spookly.kodama.brain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+import net.spookly.kodama.brain.config.NodeProperties;
+import net.spookly.kodama.brain.domain.node.Node;
+import net.spookly.kodama.brain.domain.node.NodeStatus;
+import net.spookly.kodama.brain.dto.NodeRegistrationRequest;
+import net.spookly.kodama.brain.dto.NodeRegistrationResponse;
+import net.spookly.kodama.brain.repository.NodeRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableConfigurationProperties(NodeProperties.class)
+@Import({NodeService.class, NodeProperties.class})
+class NodeServiceTest {
+
+    @Container
+    private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.4.0");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+        registry.add("node.heartbeat-interval-seconds", () -> "45");
+    }
+
+    @Autowired
+    private NodeService nodeService;
+
+    @Autowired
+    private NodeRepository nodeRepository;
+
+    @Test
+    void registerNodeCreatesNewEntity() {
+        NodeRegistrationRequest request = new NodeRegistrationRequest();
+        request.setName("node-1");
+        request.setRegion("eu-central-1");
+        request.setCapacitySlots(10);
+        request.setNodeVersion("1.0.0");
+        request.setTags("primary,ssd");
+        request.setBaseUrl("http://node-1.internal");
+
+        NodeRegistrationResponse response = nodeService.registerNode(request);
+
+        assertThat(response.getNodeId()).isNotNull();
+        assertThat(response.getHeartbeatIntervalSeconds()).isEqualTo(45);
+
+        Node persisted = nodeRepository.findById(response.getNodeId()).orElseThrow();
+        assertThat(persisted.getName()).isEqualTo("node-1");
+        assertThat(persisted.getRegion()).isEqualTo("eu-central-1");
+        assertThat(persisted.getStatus()).isEqualTo(NodeStatus.ONLINE);
+        assertThat(persisted.getCapacitySlots()).isEqualTo(10);
+        assertThat(persisted.getNodeVersion()).isEqualTo("1.0.0");
+        assertThat(persisted.getTags()).isEqualTo("primary,ssd");
+        assertThat(persisted.getBaseUrl()).isEqualTo("http://node-1.internal");
+    }
+
+    @Test
+    void registerNodeUpdatesExistingRecord() {
+        NodeRegistrationRequest request = new NodeRegistrationRequest();
+        request.setName("node-2");
+        request.setRegion("eu-central-1");
+        request.setCapacitySlots(8);
+        request.setNodeVersion("1.0.0");
+        request.setTags("primary");
+        request.setBaseUrl("http://node-2.internal");
+
+        NodeRegistrationResponse firstResponse = nodeService.registerNode(request);
+        OffsetDateTime initialHeartbeat = nodeRepository.findById(firstResponse.getNodeId())
+                .orElseThrow()
+                .getLastHeartbeatAt()
+                .truncatedTo(ChronoUnit.MICROS);
+
+        NodeRegistrationRequest updateRequest = new NodeRegistrationRequest();
+        updateRequest.setName("node-2");
+        updateRequest.setRegion("eu-west-1");
+        updateRequest.setCapacitySlots(20);
+        updateRequest.setNodeVersion("2.0.0");
+        updateRequest.setDevMode(true);
+        updateRequest.setTags("primary,arm");
+        updateRequest.setStatus(NodeStatus.OFFLINE);
+        updateRequest.setBaseUrl("http://node-2-new.internal");
+
+        NodeRegistrationResponse secondResponse = nodeService.registerNode(updateRequest);
+
+        assertThat(secondResponse.getNodeId()).isEqualTo(firstResponse.getNodeId());
+
+        Node updated = nodeRepository.findById(secondResponse.getNodeId()).orElseThrow();
+        assertThat(updated.getRegion()).isEqualTo("eu-west-1");
+        assertThat(updated.isDevMode()).isTrue();
+        assertThat(updated.getCapacitySlots()).isEqualTo(20);
+        assertThat(updated.getNodeVersion()).isEqualTo("2.0.0");
+        assertThat(updated.getStatus()).isEqualTo(NodeStatus.OFFLINE);
+        assertThat(updated.getTags()).isEqualTo("primary,arm");
+        assertThat(updated.getBaseUrl()).isEqualTo("http://node-2-new.internal");
+        assertThat(updated.getLastHeartbeatAt().truncatedTo(ChronoUnit.MICROS))
+                .isAfterOrEqualTo(initialHeartbeat);
+    }
+}

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -8,6 +8,39 @@ info:
 servers:
   - url: http://localhost:8080
 paths:
+  /api/nodes:
+    get:
+      tags: [Nodes]
+      summary: List nodes
+      responses:
+        "200":
+          description: Nodes ordered by name.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Node"
+  /api/nodes/register:
+    post:
+      tags: [Nodes]
+      summary: Register node
+      description: Insert or refresh node metadata.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NodeRegistrationRequest"
+      responses:
+        "200":
+          description: Node registered or updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NodeRegistrationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
   /api/templates:
     get:
       tags: [Templates]
@@ -108,6 +141,80 @@ components:
         type: string
         format: uuid
   schemas:
+    Node:
+      type: object
+      required: [id, name, region, status, devMode, capacitySlots, usedSlots, lastHeartbeatAt, nodeVersion]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        region:
+          type: string
+        status:
+          $ref: "#/components/schemas/NodeStatus"
+        devMode:
+          type: boolean
+        capacitySlots:
+          type: integer
+          format: int32
+        usedSlots:
+          type: integer
+          format: int32
+        lastHeartbeatAt:
+          type: string
+          format: date-time
+        nodeVersion:
+          type: string
+        tags:
+          type: string
+          nullable: true
+        baseUrl:
+          type: string
+          format: uri
+          nullable: true
+    NodeRegistrationRequest:
+      type: object
+      required: [name, region, capacitySlots, nodeVersion]
+      properties:
+        name:
+          type: string
+        region:
+          type: string
+        capacitySlots:
+          type: integer
+          format: int32
+          minimum: 1
+        nodeVersion:
+          type: string
+        devMode:
+          type: boolean
+          default: false
+        tags:
+          type: string
+          nullable: true
+        baseUrl:
+          type: string
+          format: uri
+          nullable: true
+        status:
+          $ref: "#/components/schemas/NodeStatus"
+          description: Optional override; defaults to ONLINE.
+    NodeRegistrationResponse:
+      type: object
+      required: [nodeId, heartbeatIntervalSeconds]
+      properties:
+        nodeId:
+          type: string
+          format: uuid
+        heartbeatIntervalSeconds:
+          type: integer
+          format: int32
+          description: Preferred heartbeat cadence communicated to the node.
+    NodeStatus:
+      type: string
+      enum: [ONLINE, OFFLINE, UNKNOWN]
     Template:
       type: object
       required: [id, name, description, type, createdAt, createdBy]


### PR DESCRIPTION
- Added `baseUrl` property to the `Node` entity and exposed it in APIs.
- Introduced `NodeProperties` to manage default heartbeat interval value.
- Updated `NodeService` to include heartbeat interval in registration response.
- Enhanced OpenAPI documentation with updated endpoints and new schemas.
- Created Flyway migration `V5__add_node_base_url.sql` to extend `nodes` table.
- Added tests to validate registration and update logic.

## Description
add node base URL support and default heartbeat configuration

## Linked Issues
Closes #16

## Checklist
- [x] Code is complete
- [x] Tests updated if needed
- [x] No unrelated changes
- [x] Ready for review
