### PR TITLE
feature(#17): add heartbeat API to update node status and slot usage

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
@@ -1,14 +1,17 @@
 package net.spookly.kodama.brain.controller;
 
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.validation.Valid;
 import net.spookly.kodama.brain.dto.NodeDto;
+import net.spookly.kodama.brain.dto.NodeHeartbeatRequest;
 import net.spookly.kodama.brain.dto.NodeRegistrationRequest;
 import net.spookly.kodama.brain.dto.NodeRegistrationResponse;
 import net.spookly.kodama.brain.service.NodeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,5 +37,13 @@ public class NodeController {
     @ResponseStatus(HttpStatus.OK)
     public NodeRegistrationResponse registerNode(@Valid @RequestBody NodeRegistrationRequest request) {
         return nodeService.registerNode(request);
+    }
+
+    @PostMapping("/{nodeId}/heartbeat")
+    @ResponseStatus(HttpStatus.OK)
+    public NodeDto heartbeat(
+            @PathVariable UUID nodeId,
+            @Valid @RequestBody NodeHeartbeatRequest request) {
+        return nodeService.heartbeat(nodeId, request);
     }
 }

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -41,6 +41,30 @@ paths:
                 $ref: "#/components/schemas/NodeRegistrationResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+  /api/nodes/{nodeId}/heartbeat:
+    parameters:
+      - $ref: "#/components/parameters/NodeId"
+    post:
+      tags: [Nodes]
+      summary: Send heartbeat
+      description: Update node status and slot usage.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NodeHeartbeatRequest"
+      responses:
+        "200":
+          description: Heartbeat processed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/templates:
     get:
       tags: [Templates]
@@ -132,6 +156,14 @@ paths:
           $ref: "#/components/responses/Conflict"
 components:
   parameters:
+    NodeId:
+      name: nodeId
+      in: path
+      required: true
+      description: Node identifier.
+      schema:
+        type: string
+        format: uuid
     TemplateId:
       name: id
       in: path
@@ -201,6 +233,16 @@ components:
         status:
           $ref: "#/components/schemas/NodeStatus"
           description: Optional override; defaults to ONLINE.
+    NodeHeartbeatRequest:
+      type: object
+      required: [status, usedSlots]
+      properties:
+        status:
+          $ref: "#/components/schemas/NodeStatus"
+        usedSlots:
+          type: integer
+          format: int32
+          minimum: 0
     NodeRegistrationResponse:
       type: object
       required: [nodeId, heartbeatIntervalSeconds]


### PR DESCRIPTION
- Added `NodeController` endpoint for processing node heartbeats and updating status and slot usage.
- Implemented `NodeService` logic for heartbeat validation and persistence.
- Extended OpenAPI specifications with parameters, responses, and schemas for the heartbeat endpoint.
- Introduced tests validating heartbeat functionality, including error cases for invalid slot usage.

## Description
add heartbeat API to update node status and slot usage

## Linked Issues
Closes #17

## Checklist
- [x] Code is complete
- [x] Tests updated if needed
- [x] No unrelated changes
- [x] Ready for review
