### PR TITLE
feat: add centralized instance state machine with lifecycle transitio…

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
@@ -38,6 +38,12 @@ public class NodeCallbackController {
         instanceService.reportInstanceStopped(nodeId, instanceId);
     }
 
+    @PostMapping("/destroyed")
+    @ResponseStatus(HttpStatus.OK)
+    public void destroyed(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
+        instanceService.reportInstanceDestroyed(nodeId, instanceId);
+    }
+
     @PostMapping("/failed")
     @ResponseStatus(HttpStatus.OK)
     public void failed(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/instance/Instance.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/instance/Instance.java
@@ -121,6 +121,16 @@ public class Instance {
         this.failureReason = null;
     }
 
+    public void markPreparing(OffsetDateTime timestamp) {
+        updateLifecycle(InstanceState.PREPARING, timestamp);
+        this.failureReason = null;
+    }
+
+    public void markStarting(OffsetDateTime timestamp) {
+        updateLifecycle(InstanceState.STARTING, timestamp);
+        this.failureReason = null;
+    }
+
     public void markRunning(OffsetDateTime timestamp) {
         updateLifecycle(InstanceState.RUNNING, timestamp);
         if (this.startedAt == null) {
@@ -130,8 +140,21 @@ public class Instance {
         this.failureReason = null;
     }
 
+    public void markStopping(OffsetDateTime timestamp) {
+        updateLifecycle(InstanceState.STOPPING, timestamp);
+        this.failureReason = null;
+    }
+
     public void markStopped(OffsetDateTime timestamp) {
         updateLifecycle(InstanceState.STOPPED, timestamp);
+        if (this.stoppedAt == null) {
+            this.stoppedAt = timestamp;
+        }
+        this.failureReason = null;
+    }
+
+    public void markDestroyed(OffsetDateTime timestamp) {
+        updateLifecycle(InstanceState.DESTROYED, timestamp);
         if (this.stoppedAt == null) {
             this.stoppedAt = timestamp;
         }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceStateMachine.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceStateMachine.java
@@ -1,0 +1,118 @@
+package net.spookly.kodama.brain.service;
+
+import java.time.OffsetDateTime;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import net.spookly.kodama.brain.domain.instance.Instance;
+import net.spookly.kodama.brain.domain.instance.InstanceEvent;
+import net.spookly.kodama.brain.domain.instance.InstanceEventType;
+import net.spookly.kodama.brain.domain.instance.InstanceState;
+import net.spookly.kodama.brain.repository.InstanceEventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class InstanceStateMachine {
+
+    private static final Set<InstanceState> TERMINAL_STATES =
+            EnumSet.of(InstanceState.DESTROYED, InstanceState.FAILED);
+
+    private final InstanceEventRepository instanceEventRepository;
+    private final Map<InstanceState, Set<InstanceState>> allowedTransitions;
+
+    public InstanceStateMachine(InstanceEventRepository instanceEventRepository) {
+        this.instanceEventRepository = instanceEventRepository;
+        this.allowedTransitions = buildAllowedTransitions();
+    }
+
+    public void transition(
+            Instance instance,
+            InstanceState targetState,
+            InstanceEventType eventType,
+            OffsetDateTime timestamp
+    ) {
+        transition(instance, targetState, eventType, timestamp, null);
+    }
+
+    public void transition(
+            Instance instance,
+            InstanceState targetState,
+            InstanceEventType eventType,
+            OffsetDateTime timestamp,
+            String failureReason
+    ) {
+        Objects.requireNonNull(instance, "instance");
+        Objects.requireNonNull(targetState, "targetState");
+        Objects.requireNonNull(eventType, "eventType");
+        Objects.requireNonNull(timestamp, "timestamp");
+
+        InstanceState currentState = instance.getState();
+        validateTransition(currentState, targetState);
+        if (failureReason != null && targetState != InstanceState.FAILED) {
+            throw new IllegalArgumentException("failureReason is only valid for FAILED transitions");
+        }
+
+        applyTransition(instance, targetState, timestamp, failureReason);
+        instanceEventRepository.save(new InstanceEvent(instance, timestamp, eventType, null));
+    }
+
+    private Map<InstanceState, Set<InstanceState>> buildAllowedTransitions() {
+        EnumMap<InstanceState, Set<InstanceState>> transitions = new EnumMap<>(InstanceState.class);
+        transitions.put(InstanceState.REQUESTED, EnumSet.of(InstanceState.PREPARING));
+        transitions.put(InstanceState.PREPARING, EnumSet.of(InstanceState.STARTING));
+        transitions.put(InstanceState.STARTING, EnumSet.of(InstanceState.RUNNING));
+        transitions.put(InstanceState.RUNNING, EnumSet.of(InstanceState.STOPPING));
+        transitions.put(InstanceState.STOPPING, EnumSet.of(InstanceState.DESTROYED, InstanceState.STOPPED));
+        transitions.put(InstanceState.STOPPED, EnumSet.of(InstanceState.DESTROYED, InstanceState.STARTING));
+
+        for (InstanceState state : InstanceState.values()) {
+            if (TERMINAL_STATES.contains(state)) {
+                continue;
+            }
+            transitions.computeIfAbsent(state, key -> EnumSet.noneOf(InstanceState.class))
+                    .add(InstanceState.FAILED);
+        }
+
+        return transitions;
+    }
+
+    private void validateTransition(InstanceState currentState, InstanceState targetState) {
+        if (currentState == null) {
+            throw new InvalidInstanceStateTransitionException("Instance state is not set");
+        }
+        if (currentState == targetState) {
+            throw new InvalidInstanceStateTransitionException("Instance is already in state " + currentState);
+        }
+        Set<InstanceState> allowedTargets = allowedTransitions.getOrDefault(currentState, Set.of());
+        if (!allowedTargets.contains(targetState)) {
+            throw new InvalidInstanceStateTransitionException(
+                    "Invalid instance state transition from " + currentState + " to " + targetState
+            );
+        }
+    }
+
+    private void applyTransition(
+            Instance instance,
+            InstanceState targetState,
+            OffsetDateTime timestamp,
+            String failureReason
+    ) {
+        switch (targetState) {
+            case PREPARING -> instance.markPreparing(timestamp);
+            case STARTING -> instance.markStarting(timestamp);
+            case RUNNING -> instance.markRunning(timestamp);
+            case STOPPING -> instance.markStopping(timestamp);
+            case STOPPED -> instance.markStopped(timestamp);
+            case DESTROYED -> instance.markDestroyed(timestamp);
+            case FAILED -> instance.markFailed(timestamp, failureReason);
+            default -> throw new InvalidInstanceStateTransitionException(
+                    "Unsupported target state " + targetState
+            );
+        }
+    }
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/InvalidInstanceStateTransitionException.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/InvalidInstanceStateTransitionException.java
@@ -1,0 +1,8 @@
+package net.spookly.kodama.brain.service;
+
+public class InvalidInstanceStateTransitionException extends RuntimeException {
+
+    public InvalidInstanceStateTransitionException(String message) {
+        super(message);
+    }
+}

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceStateMachineTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceStateMachineTest.java
@@ -1,0 +1,174 @@
+package net.spookly.kodama.brain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import net.spookly.kodama.brain.domain.instance.Instance;
+import net.spookly.kodama.brain.domain.instance.InstanceEvent;
+import net.spookly.kodama.brain.domain.instance.InstanceEventType;
+import net.spookly.kodama.brain.domain.instance.InstanceState;
+import net.spookly.kodama.brain.repository.InstanceEventRepository;
+import net.spookly.kodama.brain.repository.InstanceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(InstanceStateMachine.class)
+class InstanceStateMachineTest {
+
+    @Container
+    private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.4.0");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+    }
+
+    private static final UUID REQUESTER_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final String FAILURE_REASON = "node reported failure";
+
+    private static final Set<Transition> ALLOWED_TRANSITIONS = Set.of(
+            new Transition(InstanceState.REQUESTED, InstanceState.PREPARING),
+            new Transition(InstanceState.PREPARING, InstanceState.STARTING),
+            new Transition(InstanceState.STARTING, InstanceState.RUNNING),
+            new Transition(InstanceState.RUNNING, InstanceState.STOPPING),
+            new Transition(InstanceState.STOPPING, InstanceState.DESTROYED),
+            new Transition(InstanceState.STOPPING, InstanceState.STOPPED),
+            new Transition(InstanceState.STOPPED, InstanceState.DESTROYED),
+            new Transition(InstanceState.STOPPED, InstanceState.STARTING),
+            new Transition(InstanceState.REQUESTED, InstanceState.FAILED),
+            new Transition(InstanceState.PREPARING, InstanceState.FAILED),
+            new Transition(InstanceState.STARTING, InstanceState.FAILED),
+            new Transition(InstanceState.RUNNING, InstanceState.FAILED),
+            new Transition(InstanceState.STOPPING, InstanceState.FAILED),
+            new Transition(InstanceState.STOPPED, InstanceState.FAILED),
+            new Transition(InstanceState.PREPARED, InstanceState.FAILED)
+    );
+
+    @Autowired
+    private InstanceStateMachine instanceStateMachine;
+
+    @Autowired
+    private InstanceRepository instanceRepository;
+
+    @Autowired
+    private InstanceEventRepository instanceEventRepository;
+
+    @ParameterizedTest
+    @MethodSource("validTransitions")
+    void transitionAppliesValidTransitions(
+            InstanceState fromState,
+            InstanceState toState,
+            InstanceEventType eventType
+    ) {
+        Instance instance = saveInstance(fromState);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+        if (toState == InstanceState.FAILED) {
+            instanceStateMachine.transition(instance, toState, eventType, now, FAILURE_REASON);
+        } else {
+            instanceStateMachine.transition(instance, toState, eventType, now);
+        }
+
+        Instance persisted = instanceRepository.findById(instance.getId()).orElseThrow();
+        assertThat(persisted.getState()).isEqualTo(toState);
+        if (toState == InstanceState.FAILED) {
+            assertThat(persisted.getFailureReason()).isEqualTo(FAILURE_REASON);
+        }
+
+        InstanceEvent event = instanceEventRepository
+                .findAllByInstanceIdOrderByTimestampAsc(instance.getId())
+                .getFirst();
+        assertThat(event.getType()).isEqualTo(eventType);
+    }
+
+    @Test
+    void transitionRejectsInvalidTransitions() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        EnumSet<InstanceState> allStates = EnumSet.allOf(InstanceState.class);
+
+        for (InstanceState fromState : allStates) {
+            for (InstanceState toState : allStates) {
+                if (fromState == toState) {
+                    continue;
+                }
+                if (ALLOWED_TRANSITIONS.contains(new Transition(fromState, toState))) {
+                    continue;
+                }
+
+                Instance instance = buildInstance(fromState);
+                assertThatThrownBy(() ->
+                        instanceStateMachine.transition(instance, toState, InstanceEventType.FAILURE_REPORTED, now)
+                ).isInstanceOf(InvalidInstanceStateTransitionException.class);
+            }
+        }
+    }
+
+    private Instance saveInstance(InstanceState state) {
+        return instanceRepository.save(buildInstance(state));
+    }
+
+    private Instance buildInstance(InstanceState state) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        return new Instance(
+                "instance-" + UUID.randomUUID(),
+                "Instance " + state,
+                state,
+                REQUESTER_ID,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                now,
+                now
+        );
+    }
+
+    private static Stream<Arguments> validTransitions() {
+        return Stream.of(
+                Arguments.of(InstanceState.REQUESTED, InstanceState.PREPARING, InstanceEventType.PREPARE_DISPATCHED),
+                Arguments.of(InstanceState.PREPARING, InstanceState.STARTING, InstanceEventType.PREPARE_COMPLETED),
+                Arguments.of(InstanceState.STARTING, InstanceState.RUNNING, InstanceEventType.START_COMPLETED),
+                Arguments.of(InstanceState.RUNNING, InstanceState.STOPPING, InstanceEventType.STOP_DISPATCHED),
+                Arguments.of(InstanceState.STOPPING, InstanceState.STOPPED, InstanceEventType.STOP_COMPLETED),
+                Arguments.of(InstanceState.STOPPING, InstanceState.DESTROYED, InstanceEventType.DESTROY_COMPLETED),
+                Arguments.of(InstanceState.STOPPED, InstanceState.DESTROYED, InstanceEventType.DESTROY_COMPLETED),
+                Arguments.of(InstanceState.STOPPED, InstanceState.STARTING, InstanceEventType.START_DISPATCHED),
+                Arguments.of(InstanceState.REQUESTED, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.PREPARING, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.STARTING, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.RUNNING, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.STOPPING, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.STOPPED, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED),
+                Arguments.of(InstanceState.PREPARED, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED)
+        );
+    }
+
+    private record Transition(InstanceState from, InstanceState to) {
+    }
+}

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -161,6 +161,21 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+  /api/nodes/{nodeId}/instances/{instanceId}/destroyed:
+    parameters:
+      - $ref: "#/components/parameters/NodeId"
+      - $ref: "#/components/parameters/NodeInstanceId"
+    post:
+      tags: [Nodes]
+      summary: Report instance destroyed
+      description: Callback from node when an instance is destroyed.
+      responses:
+        "200":
+          description: Callback accepted.
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /api/nodes/{nodeId}/instances/{instanceId}/failed:
     parameters:
       - $ref: "#/components/parameters/NodeId"

--- a/docs/brain/instance-state-machine.md
+++ b/docs/brain/instance-state-machine.md
@@ -1,0 +1,45 @@
+# Instance State Machine
+
+## Purpose
+
+Centralize and validate instance lifecycle transitions in the Brain.
+
+## What changed
+
+- All lifecycle changes now go through `InstanceStateMachine`.
+- Each transition updates `Instance.state` and writes an `InstanceEvent`.
+
+## How to use / impact
+
+Allowed transitions:
+
+- `REQUESTED` → `PREPARING`
+- `PREPARING` → `STARTING`
+- `STARTING` → `RUNNING`
+- `RUNNING` → `STOPPING`
+- `STOPPING` → `DESTROYED`
+- `STOPPING` → `STOPPED`
+- `STOPPED` → `DESTROYED`
+- `STOPPED` → `STARTING`
+- Any non-terminal state → `FAILED`
+
+Node callbacks map to the state machine:
+
+- `/prepared` transitions to `STARTING` and logs `PREPARE_COMPLETED`.
+- `/running` transitions to `RUNNING` and logs `START_COMPLETED`.
+- `/stopped` transitions to `STOPPED` and logs `STOP_COMPLETED`.
+- `/destroyed` transitions to `DESTROYED` and logs `DESTROY_COMPLETED`.
+- `/failed` transitions to `FAILED` and logs `FAILURE_REPORTED`.
+
+Invalid transitions throw `InvalidInstanceStateTransitionException`.
+
+## Edge cases / risks
+
+- Terminal states (`FAILED`, `DESTROYED`) do not transition further.
+- Instances can transition from `STOPPED` to `STARTING` to restart without re-preparing.
+- Ensure a `STOPPING` transition is recorded before a node reports a stop/destroy callback.
+
+## Links
+
+- `backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceStateMachine.java`
+- `docs/brain/node-callback-endpoints.md`

--- a/docs/brain/node-callback-endpoints.md
+++ b/docs/brain/node-callback-endpoints.md
@@ -7,7 +7,7 @@ Base path: `/api/nodes/{nodeId}/instances/{instanceId}`
 ## Endpoints
 
 - `POST /prepared`
-  - Updates instance state to `PREPARED`.
+  - Updates instance state to `STARTING`.
   - Logs `PREPARE_COMPLETED` event.
 - `POST /running`
   - Updates instance state to `RUNNING`.
@@ -15,6 +15,9 @@ Base path: `/api/nodes/{nodeId}/instances/{instanceId}`
 - `POST /stopped`
   - Updates instance state to `STOPPED`.
   - Logs `STOP_COMPLETED` event.
+- `POST /destroyed`
+  - Updates instance state to `DESTROYED`.
+  - Logs `DESTROY_COMPLETED` event.
 - `POST /failed`
   - Updates instance state to `FAILED`.
   - Logs `FAILURE_REPORTED` event.


### PR DESCRIPTION
## Description
add centralized instance state machine with lifecycle transitions

- Implemented `InstanceStateMachine` for managing instance lifecycle transitions.
- Updated `InstanceService` and added state-specific transition methods to `Instance`.
- Introduced new endpoints for `/destroyed` and improved state handling for callbacks.
- Added tests for state transitions and edge cases.
- Updated OpenAPI specs and documentation to reflect changes.

## Linked Issues
Closes #24

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
