### PR TITLE
feat: implement user and role management for RBAC in Brain module

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/RoleEntity.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/RoleEntity.java
@@ -1,4 +1,37 @@
 package net.spookly.kodama.brain.domain.user;
 
+import java.util.Objects;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.spookly.kodama.brain.security.Role;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoleEntity {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, unique = true, length = 32)
+    private Role name;
+
+    public RoleEntity(Role name) {
+        this.name = Objects.requireNonNull(name, "name");
+    }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/User.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/User.java
@@ -1,4 +1,60 @@
 package net.spookly.kodama.brain.domain.user;
 
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "display_name", nullable = false)
+    private String displayName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "auth_provider", nullable = false, length = 64)
+    private String authProvider;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<UserRole> userRoles = new HashSet<>();
+
+    public User(String username, String displayName, String email, String authProvider, String externalId) {
+        this.username = Objects.requireNonNull(username, "username");
+        this.displayName = Objects.requireNonNull(displayName, "displayName");
+        this.email = Objects.requireNonNull(email, "email");
+        this.authProvider = Objects.requireNonNull(authProvider, "authProvider");
+        this.externalId = externalId;
+    }
+
+    public void addRole(RoleEntity role) {
+        userRoles.add(new UserRole(this, role));
+    }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/UserRole.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/UserRole.java
@@ -1,0 +1,39 @@
+package net.spookly.kodama.brain.domain.user;
+
+import java.util.Objects;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_roles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRole {
+
+    @EmbeddedId
+    private UserRoleId id = new UserRoleId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("userId")
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleId")
+    @JoinColumn(name = "role_id", nullable = false)
+    private RoleEntity role;
+
+    public UserRole(User user, RoleEntity role) {
+        this.user = Objects.requireNonNull(user, "user");
+        this.role = Objects.requireNonNull(role, "role");
+    }
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/UserRoleId.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/UserRoleId.java
@@ -1,0 +1,27 @@
+package net.spookly.kodama.brain.domain.user;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class UserRoleId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "role_id", nullable = false)
+    private UUID roleId;
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/repository/RoleRepository.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/repository/RoleRepository.java
@@ -1,4 +1,14 @@
 package net.spookly.kodama.brain.repository;
 
-public class RoleRepository {
+import java.util.Optional;
+import java.util.UUID;
+
+import lombok.NonNull;
+import net.spookly.kodama.brain.domain.user.RoleEntity;
+import net.spookly.kodama.brain.security.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<@NonNull RoleEntity, @NonNull UUID> {
+
+    Optional<RoleEntity> findByName(Role name);
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/repository/UserRepository.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package net.spookly.kodama.brain.repository;
 
-public class UserRepository {
+import java.util.UUID;
+
+import lombok.NonNull;
+import net.spookly.kodama.brain.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<@NonNull User, @NonNull UUID> {
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/repository/UserRoleRepository.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/repository/UserRoleRepository.java
@@ -1,0 +1,9 @@
+package net.spookly.kodama.brain.repository;
+
+import lombok.NonNull;
+import net.spookly.kodama.brain.domain.user.UserRole;
+import net.spookly.kodama.brain.domain.user.UserRoleId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRoleRepository extends JpaRepository<@NonNull UserRole, @NonNull UserRoleId> {
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/security/Role.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/security/Role.java
@@ -1,4 +1,7 @@
 package net.spookly.kodama.brain.security;
 
-public class Role {
+public enum Role {
+    ADMIN,
+    OPERATOR,
+    VIEWER
 }

--- a/backend/brain/src/main/resources/db/migration/V10__create_user_role_tables.sql
+++ b/backend/brain/src/main/resources/db/migration/V10__create_user_role_tables.sql
@@ -1,0 +1,35 @@
+CREATE TABLE users (
+    id BINARY(16) NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    auth_provider VARCHAR(64) NOT NULL,
+    external_id VARCHAR(255) NULL,
+    CONSTRAINT pk_users PRIMARY KEY (id),
+    CONSTRAINT uq_users_username UNIQUE (username),
+    CONSTRAINT uq_users_email UNIQUE (email)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE roles (
+    id BINARY(16) NOT NULL,
+    name VARCHAR(32) NOT NULL,
+    CONSTRAINT pk_roles PRIMARY KEY (id),
+    CONSTRAINT uq_roles_name UNIQUE (name),
+    CONSTRAINT chk_roles_name CHECK (name IN ('ADMIN', 'OPERATOR', 'VIEWER'))
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE user_roles (
+    user_id BINARY(16) NOT NULL,
+    role_id BINARY(16) NOT NULL,
+    CONSTRAINT pk_user_roles PRIMARY KEY (user_id, role_id),
+    CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles (id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE INDEX idx_user_roles_role_id ON user_roles (role_id);

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/repository/UserRepositoryTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/repository/UserRepositoryTest.java
@@ -1,0 +1,58 @@
+package net.spookly.kodama.brain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.spookly.kodama.brain.domain.user.RoleEntity;
+import net.spookly.kodama.brain.domain.user.User;
+import net.spookly.kodama.brain.security.Role;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=validate")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+    @Container
+    private static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.4.0");
+
+    @DynamicPropertySource
+    static void configureDatasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+    }
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Test
+    void saveUserWithRoles() {
+        RoleEntity admin = roleRepository.save(new RoleEntity(Role.ADMIN));
+        RoleEntity viewer = roleRepository.save(new RoleEntity(Role.VIEWER));
+
+        User user = new User("nina", "Nina Winters", "nina@example.com", "local", "nina-1");
+        user.addRole(admin);
+        user.addRole(viewer);
+
+        User saved = userRepository.save(user);
+        User persisted = userRepository.findById(saved.getId()).orElseThrow();
+
+        assertThat(persisted.getUsername()).isEqualTo("nina");
+        assertThat(persisted.getEmail()).isEqualTo("nina@example.com");
+        assertThat(persisted.getUserRoles())
+                .extracting(userRole -> userRole.getRole().getName())
+                .containsExactlyInAnyOrder(Role.ADMIN, Role.VIEWER);
+    }
+}

--- a/docs/brain/user-role-model.md
+++ b/docs/brain/user-role-model.md
@@ -1,0 +1,25 @@
+# User & Role Model
+
+## Purpose
+Define the core user/role data model used by the Brain module for RBAC and future auth flows.
+
+## What changed
+- Added `User`, `RoleEntity`, and `UserRole` entities to the Brain domain.
+- Added repositories for users, roles, and user-role mappings.
+- Added a Flyway migration to create `users`, `roles`, and `user_roles` tables.
+- Defined `Role` as an enum for `ADMIN`, `OPERATOR`, and `VIEWER`.
+
+## How to use / impact
+- Create roles first, then assign them to users through `User.addRole`.
+- Persist `User` to write `user_roles` via cascade.
+- Role values are stored as strings matching the `Role` enum names.
+
+## Edge cases / risks
+- Duplicate user-role pairs will be rejected by the `user_roles` primary key.
+- Roles are currently created via persistence; there is no seed data.
+
+## Links
+- Migration: `backend/brain/src/main/resources/db/migration/V10__create_user_role_tables.sql`
+- Entities: `backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/User.java`
+- Entities: `backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/RoleEntity.java`
+- Entities: `backend/brain/src/main/java/net/spookly/kodama/brain/domain/user/UserRole.java`


### PR DESCRIPTION
- Added `User`, `RoleEntity`, `UserRole` entities and mapped relationships.
- Created repositories for managing users, roles, and role assignments.
- Designed Flyway migration to create `users`, `roles`, and `user_roles` tables.
- Introduced `Role` enum with `ADMIN`, `OPERATOR`, and `VIEWER` values.
- Added unit tests for `UserRepository` and role assignment logic.

## Description
What does this PR do?

## Linked Issues
Closes #25

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
