### PR TITLE
feat: add node authentication token support and enforce on node-specific endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ When creating tests:
 - Use **Testcontainers** for integration tests that touch Docker or MySQL.
 - Do not mock the Docker Engine if you can use Testcontainers to simulate it.
 - Keep unit tests fast and focused on core logic (e.g. scheduling decisions).
+- Run tests locally with `./gradlew test` or `./gradlew test --tests <test_class_name>`
 
 ---
 

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/config/BrainSecurityProperties.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/config/BrainSecurityProperties.java
@@ -19,6 +19,8 @@ public class BrainSecurityProperties {
 
     private List<UserDefinition> users = new ArrayList<>();
 
+    private NodeAuth node = new NodeAuth();
+
     public void validate() {
         if (!enabled) {
             return;
@@ -58,6 +60,15 @@ public class BrainSecurityProperties {
                         "brain.security.users.roles must be configured for " + user.getUsername());
             }
         }
+        if (node == null) {
+            throw new IllegalStateException("brain.security.node must be configured");
+        }
+        if (node.getToken() == null || node.getToken().isBlank()) {
+            throw new IllegalStateException("brain.security.node.token must be configured");
+        }
+        if (node.getHeaderName() == null || node.getHeaderName().isBlank()) {
+            throw new IllegalStateException("brain.security.node.header-name must be configured");
+        }
     }
 
     public boolean isEnabled() {
@@ -82,6 +93,14 @@ public class BrainSecurityProperties {
 
     public void setUsers(List<UserDefinition> users) {
         this.users = users;
+    }
+
+    public NodeAuth getNode() {
+        return node;
+    }
+
+    public void setNode(NodeAuth node) {
+        this.node = node;
     }
 
     public static class Jwt {
@@ -163,6 +182,29 @@ public class BrainSecurityProperties {
 
         public void setRoles(Set<Role> roles) {
             this.roles = roles;
+        }
+    }
+
+    public static class NodeAuth {
+
+        private String token;
+
+        private String headerName = "X-Node-Token";
+
+        public String getToken() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+
+        public String getHeaderName() {
+            return headerName;
+        }
+
+        public void setHeaderName(String headerName) {
+            this.headerName = headerName;
         }
     }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
@@ -23,35 +23,35 @@ public class NodeCallbackController {
 
     @PostMapping("/prepared")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public void prepared(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
         instanceService.reportInstancePrepared(nodeId, instanceId);
     }
 
     @PostMapping("/running")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public void running(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
         instanceService.reportInstanceRunning(nodeId, instanceId);
     }
 
     @PostMapping("/stopped")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public void stopped(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
         instanceService.reportInstanceStopped(nodeId, instanceId);
     }
 
     @PostMapping("/destroyed")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public void destroyed(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
         instanceService.reportInstanceDestroyed(nodeId, instanceId);
     }
 
     @PostMapping("/failed")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public void failed(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
         instanceService.reportInstanceFailed(nodeId, instanceId);
     }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeController.java
@@ -37,14 +37,14 @@ public class NodeController {
 
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public NodeRegistrationResponse registerNode(@Valid @RequestBody NodeRegistrationRequest request) {
         return nodeService.registerNode(request);
     }
 
     @PostMapping("/{nodeId}/heartbeat")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_NODE')")
     public NodeDto heartbeat(
             @PathVariable UUID nodeId,
             @Valid @RequestBody NodeHeartbeatRequest request) {

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/TemplateController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/TemplateController.java
@@ -43,14 +43,14 @@ public class TemplateController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public TemplateDto createTemplate(@Valid @RequestBody CreateTemplateRequest request) {
         return templateService.createTemplate(request);
     }
 
     @PostMapping("/{id}/versions")
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     public TemplateVersionDto addVersion(
             @PathVariable UUID id,
             @Valid @RequestBody CreateTemplateVersionRequest request

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/security/JwtAuthFilter.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/security/JwtAuthFilter.java
@@ -29,7 +29,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
-        return path.equals("/api/auth/login") || path.startsWith("/actuator");
+        return path.equals("/api/auth/login")
+                || path.startsWith("/actuator")
+                || NodeAuthRequestMatcher.matches(request);
     }
 
     @Override

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/security/NodeAuthFilter.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/security/NodeAuthFilter.java
@@ -1,4 +1,85 @@
 package net.spookly.kodama.brain.security;
 
-public class NodeAuthFilter {
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import net.spookly.kodama.brain.config.BrainSecurityProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class NodeAuthFilter extends OncePerRequestFilter {
+
+    private static final String NODE_AUTHORITY = "ROLE_NODE";
+
+    private final BrainSecurityProperties securityProperties;
+
+    public NodeAuthFilter(BrainSecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!securityProperties.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if (!NodeAuthRequestMatcher.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        BrainSecurityProperties.NodeAuth nodeAuth = securityProperties.getNode();
+        String expectedToken = nodeAuth == null ? null : nodeAuth.getToken();
+        if (expectedToken == null || expectedToken.isBlank()) {
+            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Node authentication is not configured");
+            return;
+        }
+        String headerName = nodeAuth.getHeaderName();
+        if (headerName == null || headerName.isBlank()) {
+            response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Node authentication header is not configured");
+            return;
+        }
+        String providedToken = request.getHeader(headerName);
+        if (providedToken == null || providedToken.isBlank()) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Missing node authentication token");
+            return;
+        }
+        if (!tokensMatch(expectedToken, providedToken)) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Invalid node authentication token");
+            return;
+        }
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "node",
+                null,
+                AuthorityUtils.createAuthorityList(NODE_AUTHORITY)
+        );
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean tokensMatch(String expectedToken, String providedToken) {
+        byte[] expectedBytes = expectedToken.getBytes(StandardCharsets.UTF_8);
+        byte[] providedBytes = providedToken.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expectedBytes, providedBytes);
+    }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/security/NodeAuthRequestMatcher.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/security/NodeAuthRequestMatcher.java
@@ -1,0 +1,59 @@
+package net.spookly.kodama.brain.security;
+
+import java.util.List;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.AntPathMatcher;
+
+public final class NodeAuthRequestMatcher {
+
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    private static final List<String> NODE_AUTH_PATHS = List.of(
+            "/api/nodes/register",
+            "/api/nodes/*/heartbeat",
+            "/api/nodes/*/instances/*/prepared",
+            "/api/nodes/*/instances/*/running",
+            "/api/nodes/*/instances/*/stopped",
+            "/api/nodes/*/instances/*/destroyed",
+            "/api/nodes/*/instances/*/failed"
+    );
+
+    private NodeAuthRequestMatcher() {
+    }
+
+    public static boolean matches(HttpServletRequest request) {
+        if (request == null) {
+            return false;
+        }
+        String requestUri = request.getRequestURI();
+        if (matchesPath(requestUri)) {
+            return true;
+        }
+        String normalized = normalizePath(requestUri, request.getContextPath());
+        return matchesPath(normalized);
+    }
+
+    public static boolean matchesPath(String path) {
+        if (path == null || path.isBlank()) {
+            return false;
+        }
+        for (String pattern : NODE_AUTH_PATHS) {
+            if (PATH_MATCHER.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String normalizePath(String path, String contextPath) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
+            String normalized = path.substring(contextPath.length());
+            return normalized.isEmpty() ? "/" : normalized;
+        }
+        return path;
+    }
+}

--- a/backend/brain/src/main/resources/application.yml
+++ b/backend/brain/src/main/resources/application.yml
@@ -30,6 +30,9 @@ brain:
       issuer: ${BRAIN_JWT_ISSUER:kodama-brain}
       secret: ${BRAIN_JWT_SECRET:}
       token-ttl-seconds: ${BRAIN_JWT_TTL_SECONDS:3600}
+    node:
+      token: ${BRAIN_NODE_AUTH_TOKEN:}
+      header-name: ${BRAIN_NODE_AUTH_HEADER_NAME:X-Node-Token}
     users:
       - username: ${BRAIN_ADMIN_USERNAME:admin}
         display-name: ${BRAIN_ADMIN_DISPLAY_NAME:Admin}

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/security/JwtTokenServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/security/JwtTokenServiceTest.java
@@ -20,6 +20,10 @@ class JwtTokenServiceTest {
         jwt.setSecret("01234567890123456789012345678901");
         jwt.setTokenTtlSeconds(3600);
         securityProperties.setJwt(jwt);
+        BrainSecurityProperties.NodeAuth nodeAuth = new BrainSecurityProperties.NodeAuth();
+        nodeAuth.setToken("test-node-token");
+        nodeAuth.setHeaderName("X-Node-Token");
+        securityProperties.setNode(nodeAuth);
 
         BrainSecurityProperties.UserDefinition user = new BrainSecurityProperties.UserDefinition();
         user.setUsername("admin");

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthFilterTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthFilterTest.java
@@ -1,0 +1,94 @@
+package net.spookly.kodama.brain.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+
+import net.spookly.kodama.brain.config.BrainSecurityProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class NodeAuthFilterTest {
+
+    private NodeAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        BrainSecurityProperties securityProperties = new BrainSecurityProperties();
+        securityProperties.setEnabled(true);
+        BrainSecurityProperties.NodeAuth nodeAuth = new BrainSecurityProperties.NodeAuth();
+        nodeAuth.setToken("test-node-token");
+        nodeAuth.setHeaderName("X-Node-Token");
+        securityProperties.setNode(nodeAuth);
+        filter = new NodeAuthFilter(securityProperties);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void validTokenAuthenticatesNode() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/nodes/register");
+        request.addHeader("X-Node-Token", "test-node-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        assertTrue(authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_NODE")));
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+    }
+
+    @Test
+    void missingTokenOnNodeEndpointIsUnauthorized() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/nodes/register");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+    }
+
+    @Test
+    void invalidTokenOnNodeEndpointIsUnauthorized() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/nodes/register");
+        request.addHeader("X-Node-Token", "invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+    }
+
+    @Test
+    void nonNodeEndpointSkipsTokenCheck() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/instances");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(HttpStatus.OK.value(), response.getStatus());
+    }
+}

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthIntegrationTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthIntegrationTest.java
@@ -1,0 +1,185 @@
+package net.spookly.kodama.brain.security;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import net.spookly.kodama.brain.config.BrainSecurityProperties;
+import net.spookly.kodama.brain.config.MethodSecurityConfig;
+import net.spookly.kodama.brain.config.SecurityConfig;
+import net.spookly.kodama.brain.controller.NodeCallbackController;
+import net.spookly.kodama.brain.controller.NodeController;
+import net.spookly.kodama.brain.domain.node.NodeStatus;
+import net.spookly.kodama.brain.dto.NodeDto;
+import net.spookly.kodama.brain.dto.NodeRegistrationResponse;
+import net.spookly.kodama.brain.service.InstanceService;
+import net.spookly.kodama.brain.service.NodeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {NodeController.class, NodeCallbackController.class})
+@EnableConfigurationProperties(BrainSecurityProperties.class)
+@Import({
+        SecurityConfig.class,
+        MethodSecurityConfig.class,
+        JwtAuthFilter.class,
+        JwtTokenService.class,
+        NodeAuthFilter.class,
+        TestSecurityBootstrapConfig.class
+})
+@TestPropertySource(properties = {
+        "brain.security.enabled=true",
+        "brain.security.jwt.issuer=kodama-test",
+        "brain.security.jwt.secret=01234567890123456789012345678901",
+        "brain.security.jwt.token-ttl-seconds=3600",
+        "brain.security.node.token=test-node-token",
+        "brain.security.users[0].username=admin",
+        "brain.security.users[0].display-name=Admin",
+        "brain.security.users[0].email=admin@example.com",
+        "brain.security.users[0].password={noop}test-pass",
+        "brain.security.users[0].roles=ADMIN"
+})
+class NodeAuthIntegrationTest {
+
+    private static final String NODE_TOKEN_HEADER = "X-Node-Token";
+    private static final String NODE_TOKEN_VALUE = "test-node-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NodeService nodeService;
+
+    @MockitoBean
+    private InstanceService instanceService;
+
+    @Test
+    void registerNodeWithoutTokenIsUnauthorized() throws Exception {
+        String body = """
+                {
+                  "name": "node-1",
+                  "region": "eu-west",
+                  "capacitySlots": 10,
+                  "nodeVersion": "1.0.0",
+                  "devMode": false
+                }
+                """;
+
+        mockMvc.perform(post("/api/nodes/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void registerNodeWithTokenIsOk() throws Exception {
+        given(nodeService.registerNode(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new NodeRegistrationResponse(
+                        UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                        30
+                ));
+
+        String body = """
+                {
+                  "name": "node-1",
+                  "region": "eu-west",
+                  "capacitySlots": 10,
+                  "nodeVersion": "1.0.0",
+                  "devMode": false
+                }
+                """;
+
+        mockMvc.perform(post("/api/nodes/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .header(NODE_TOKEN_HEADER, NODE_TOKEN_VALUE))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void registerNodeWithUserTokenIsUnauthorized() throws Exception {
+        UserPrincipal principal = new UserPrincipal("admin", "Admin", "admin@example.com", Set.of(Role.ADMIN));
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.getAuthorities()
+        );
+
+        String body = """
+                {
+                  "name": "node-1",
+                  "region": "eu-west",
+                  "capacitySlots": 10,
+                  "nodeVersion": "1.0.0",
+                  "devMode": false
+                }
+                """;
+
+        mockMvc.perform(post("/api/nodes/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .with(authentication(authenticationToken)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void heartbeatWithTokenIsOk() throws Exception {
+        given(nodeService.heartbeat(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()
+        )).willReturn(new NodeDto(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                "node-1",
+                "eu-west",
+                NodeStatus.ONLINE,
+                false,
+                10,
+                2,
+                OffsetDateTime.parse("2024-01-01T00:00:00Z"),
+                "1.0.0",
+                null,
+                null
+        ));
+
+        String body = """
+                {
+                  "status": "ONLINE",
+                  "usedSlots": 2
+                }
+                """;
+
+        mockMvc.perform(post("/api/nodes/00000000-0000-0000-0000-000000000001/heartbeat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .header(NODE_TOKEN_HEADER, NODE_TOKEN_VALUE))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void preparedCallbackWithoutTokenIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/nodes/00000000-0000-0000-0000-000000000001/instances"
+                        + "/00000000-0000-0000-0000-000000000002/prepared"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void preparedCallbackWithTokenIsOk() throws Exception {
+        mockMvc.perform(post("/api/nodes/00000000-0000-0000-0000-000000000001/instances"
+                        + "/00000000-0000-0000-0000-000000000002/prepared")
+                        .header(NODE_TOKEN_HEADER, NODE_TOKEN_VALUE))
+                .andExpect(status().isOk());
+    }
+}

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -118,6 +118,8 @@ paths:
       tags: [Nodes]
       summary: Register node
       description: Insert or refresh node metadata.
+      security:
+        - nodeToken: []
       requestBody:
         required: true
         content:
@@ -144,6 +146,8 @@ paths:
       tags: [Nodes]
       summary: Send heartbeat
       description: Update node status and slot usage.
+      security:
+        - nodeToken: []
       requestBody:
         required: true
         content:
@@ -173,6 +177,8 @@ paths:
       tags: [Nodes]
       summary: Report instance prepared
       description: Callback from node when an instance finishes preparation.
+      security:
+        - nodeToken: []
       responses:
         "200":
           description: Callback accepted.
@@ -192,6 +198,8 @@ paths:
       tags: [Nodes]
       summary: Report instance running
       description: Callback from node when an instance is running.
+      security:
+        - nodeToken: []
       responses:
         "200":
           description: Callback accepted.
@@ -211,6 +219,8 @@ paths:
       tags: [Nodes]
       summary: Report instance stopped
       description: Callback from node when an instance stops.
+      security:
+        - nodeToken: []
       responses:
         "200":
           description: Callback accepted.
@@ -230,6 +240,8 @@ paths:
       tags: [Nodes]
       summary: Report instance destroyed
       description: Callback from node when an instance is destroyed.
+      security:
+        - nodeToken: []
       responses:
         "200":
           description: Callback accepted.
@@ -249,6 +261,8 @@ paths:
       tags: [Nodes]
       summary: Report instance failed
       description: Callback from node when an instance reports failure.
+      security:
+        - nodeToken: []
       responses:
         "200":
           description: Callback accepted.
@@ -375,6 +389,11 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    nodeToken:
+      type: apiKey
+      in: header
+      name: X-Node-Token
+      description: Shared token required for node callbacks and registration.
   parameters:
     InstanceId:
       name: id

--- a/docs/brain/authentication.md
+++ b/docs/brain/authentication.md
@@ -7,12 +7,22 @@ Describe the JWT-based authentication used by the Brain admin API.
 - Added `/api/auth/login` for credential exchange.
 - Added JWT bearer authentication for admin endpoints.
 - Enforced role-based access using `ADMIN`, `OPERATOR`, and `VIEWER`.
+- Added a node authentication token for node callbacks, registration, and heartbeats.
 
 ## How to use / impact
 - Configure the JWT settings and users via `brain.security` properties.
 - Obtain a token by calling `POST /api/auth/login` with `username` and `password`.
 - Send `Authorization: Bearer <token>` on protected requests.
-- All `/api/**` endpoints are protected except `/api/auth/login`.
+- Use `X-Node-Token: <token>` for node endpoints:
+  - `POST /api/nodes/register`
+  - `POST /api/nodes/{nodeId}/heartbeat`
+  - `POST /api/nodes/{nodeId}/instances/{instanceId}/*`
+- User tokens are not accepted on node callback endpoints.
+
+Role access summary:
+- `ADMIN`: full access to all user-facing endpoints.
+- `OPERATOR`: manage instances, read-only access to nodes/templates.
+- `VIEWER`: read-only access to lists and details.
 
 Required configuration (example):
 
@@ -24,6 +34,9 @@ brain:
       issuer: kodama-brain
       secret: ${BRAIN_JWT_SECRET}
       token-ttl-seconds: 3600
+    node:
+      token: ${BRAIN_NODE_AUTH_TOKEN}
+      header-name: X-Node-Token
     users:
       - username: admin
         display-name: Admin
@@ -39,6 +52,7 @@ Password values without a `{id}` prefix are treated as `{noop}` for development.
 - Missing or invalid tokens return `401 Unauthorized`.
 - Tokens expire after `token-ttl-seconds` and must be refreshed via login.
 - `VIEWER` tokens are read-only; write endpoints return `403 Forbidden`.
+- Node endpoints require `brain.security.node.token` to be configured.
 - Set `brain.security.enabled=false` to disable HTTP and method security in local development.
 
 ## Links

--- a/docs/brain/node-callback-endpoints.md
+++ b/docs/brain/node-callback-endpoints.md
@@ -26,10 +26,11 @@ Base path: `/api/nodes/{nodeId}/instances/{instanceId}`
 
 - `nodeId` must exist.
 - `instanceId` must exist and be assigned to the provided `nodeId`.
-- Requires a bearer token with `ADMIN` or `OPERATOR` role.
+- Requires the node authentication token via `X-Node-Token`.
 
 ## Responses
 
 - `200 OK` for valid callbacks.
+- `401 Unauthorized` when the node token is missing or invalid.
 - `404 Not Found` when node or instance does not exist.
 - `409 Conflict` when the instance is not assigned to the node.


### PR DESCRIPTION
## Description
- Introduced `NodeAuthFilter` to handle node token validation and secure callbacks, registration, and heartbeat endpoints.
- Updated `BrainSecurityProperties` to include `node` authentication configuration.
- Adjusted role-based access annotations to use `ROLE_NODE` for node endpoints.
- Enhanced integration tests to cover node authentication scenarios.
- Extended OpenAPI documentation to include `X-Node-Token`-based security for relevant operations.

## Linked Issues
Closes #27

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
