### PR TITLE
feat(#46): initialize Node Agent module

### DIFF
--- a/backend/node-agent/build.gradle
+++ b/backend/node-agent/build.gradle
@@ -1,20 +1,24 @@
 plugins {
-    id 'application'
+    id 'java'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
 }
 
 dependencies {
     implementation project(':common')
 
+    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
-    implementation 'org.slf4j:slf4j-simple:2.0.13'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+    implementation 'com.github.docker-java:docker-java-api:3.3.6'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-application {
+bootJar {
+    archiveBaseName = 'kodama-node-agent'
+}
+
+springBoot {
     mainClass = 'net.spookly.kodama.nodeagent.NodeAgentApplication'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentApplication.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentApplication.java
@@ -1,4 +1,15 @@
 package net.spookly.kodama.nodeagent;
 
+import net.spookly.kodama.nodeagent.config.NodeAgentProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(NodeAgentProperties.class)
 public class NodeAgentApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NodeAgentApplication.class, args);
+    }
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentStartupLogger.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentStartupLogger.java
@@ -1,0 +1,39 @@
+package net.spookly.kodama.nodeagent;
+
+import net.spookly.kodama.nodeagent.config.NodeAgentProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NodeAgentStartupLogger implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(NodeAgentStartupLogger.class);
+
+    private final NodeAgentProperties properties;
+
+    public NodeAgentStartupLogger(NodeAgentProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        logger.info(
+                "Node agent started. nodeId={}, nodeName={}, workspaceDir={}, brainBaseUrl={}, dockerHost={}",
+                properties.getNodeId(),
+                properties.getNodeName(),
+                properties.getWorkspaceDir(),
+                valueOrDash(properties.getBrainBaseUrl()),
+                valueOrDash(properties.getDockerHost())
+        );
+    }
+
+    private String valueOrDash(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        return value;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeAgentProperties.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeAgentProperties.java
@@ -1,0 +1,53 @@
+package net.spookly.kodama.nodeagent.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "node-agent")
+public class NodeAgentProperties {
+
+    private String nodeId = "local";
+    private String nodeName = "local-node";
+    private String brainBaseUrl = "";
+    private String dockerHost = "";
+    private String workspaceDir = "./data";
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public void setNodeName(String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    public String getBrainBaseUrl() {
+        return brainBaseUrl;
+    }
+
+    public void setBrainBaseUrl(String brainBaseUrl) {
+        this.brainBaseUrl = brainBaseUrl;
+    }
+
+    public String getDockerHost() {
+        return dockerHost;
+    }
+
+    public void setDockerHost(String dockerHost) {
+        this.dockerHost = dockerHost;
+    }
+
+    public String getWorkspaceDir() {
+        return workspaceDir;
+    }
+
+    public void setWorkspaceDir(String workspaceDir) {
+        this.workspaceDir = workspaceDir;
+    }
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  application:
+    name: kodama-node-agent
+  main:
+    web-application-type: none
+
+node-agent:
+  node-id: ${NODE_AGENT_ID:local}
+  node-name: ${NODE_AGENT_NAME:local-node}
+  brain-base-url: ${NODE_AGENT_BRAIN_BASE_URL:}
+  docker-host: ${NODE_AGENT_DOCKER_HOST:}
+  workspace-dir: ${NODE_AGENT_WORKSPACE_DIR:./data}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/NodeAgentApplicationTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/NodeAgentApplicationTest.java
@@ -1,0 +1,22 @@
+package net.spookly.kodama.nodeagent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.spookly.kodama.nodeagent.config.NodeAgentProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NodeAgentApplicationTest {
+
+    @Autowired
+    private NodeAgentProperties properties;
+
+    @Test
+    void loadsDefaultConfiguration() {
+        assertThat(properties.getNodeId()).isEqualTo("local");
+        assertThat(properties.getNodeName()).isEqualTo("local-node");
+        assertThat(properties.getWorkspaceDir()).isEqualTo("./data");
+    }
+}

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -1,0 +1,25 @@
+# Node Agent Overview
+
+## Purpose
+The Node Agent is a lightweight Java service that runs on each node and executes Brain commands.
+
+## What changed
+- Added a Node Agent module skeleton with a Spring Boot entrypoint.
+- Added minimal configuration wiring and a startup log line.
+
+## How to use / impact
+- Build and run with `./gradlew :node-agent:bootRun` from `backend/`.
+- Configure via environment variables:
+  - `NODE_AGENT_ID`
+  - `NODE_AGENT_NAME`
+  - `NODE_AGENT_WORKSPACE_DIR`
+  - `NODE_AGENT_BRAIN_BASE_URL`
+  - `NODE_AGENT_DOCKER_HOST`
+
+## Edge cases / risks
+- `NODE_AGENT_BRAIN_BASE_URL` and `NODE_AGENT_DOCKER_HOST` can be left empty for now; no connections are attempted.
+- The workspace directory is not created automatically yet.
+
+## Links
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentApplication.java`
+- `backend/node-agent/src/main/resources/application.yml`


### PR DESCRIPTION
## Description
- Add Node Agent Spring Boot application with configuration wiring.
- Implement `NodeAgentProperties` for environment-based configuration.
- Add startup logger for node identification and workspace details.
- Provide initial tests for default configuration loading.
- Include documentation for setup, usage, and configuration.

## Linked Issues
Closes #46

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
