### PR TITLE
feat(#48): implement Brain registration in Node Agent startup

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentStartupLogger.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentStartupLogger.java
@@ -5,9 +5,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Component
+@Order(Ordered.LOWEST_PRECEDENCE)
 public class NodeAgentStartupLogger implements ApplicationRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(NodeAgentStartupLogger.class);
@@ -20,15 +23,25 @@ public class NodeAgentStartupLogger implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        config.validate();
         logger.info(
-                "Node agent started with config. nodeId={}, nodeName={}, brainBaseUrl={}, dockerHost={}, workspaceDir={}, cacheDir={}, authTokenPath={}, authCertPath={}, s3Endpoint={}, s3Region={}, s3Bucket={}, s3AccessKey={}, s3SecretKey={}",
-                config.getNodeId(),
+                "Node agent started with config. nodeId={}, nodeName={}, nodeVersion={}, region={}, capacitySlots={}, " +
+                        "devMode={}, tags={}, baseUrl={}, brainBaseUrl={}, registrationEnabled={}, dockerHost={}, " +
+                        "workspaceDir={}, cacheDir={}, authHeaderName={}, authTokenPath={}, authCertPath={}, " +
+                        "s3Endpoint={}, s3Region={}, s3Bucket={}, s3AccessKey={}, s3SecretKey={}",
+                valueOrDash(config.getNodeId()),
                 config.getNodeName(),
+                config.getNodeVersion(),
+                config.getRegion(),
+                config.getCapacitySlots(),
+                config.isDevMode(),
+                valueOrDash(config.getTags()),
+                valueOrDash(config.getBaseUrl()),
                 config.getBrainBaseUrl(),
+                config.isRegistrationEnabled(),
                 valueOrDash(config.getDockerHost()),
                 config.getWorkspaceDir(),
                 config.getCacheDir(),
+                valueOrDash(config.getAuth().getHeaderName()),
                 valueOrDash(config.getAuth().getTokenPath()),
                 valueOrDash(config.getAuth().getCertPath()),
                 valueOrDash(config.getS3().getEndpoint()),

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/JacksonConfig.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package net.spookly.kodama.nodeagent.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
@@ -10,19 +10,30 @@ public class NodeConfig {
 
     private String nodeId;
     private String nodeName;
+    private String nodeVersion;
+    private String region;
+    private int capacitySlots;
+    private boolean devMode;
+    private String tags;
+    private String baseUrl;
     private String brainBaseUrl;
     private String dockerHost;
     private String workspaceDir = "./data";
     private String cacheDir;
+    private boolean registrationEnabled = true;
     private Auth auth = new Auth();
     private S3 s3 = new S3();
 
     public void validate() {
         List<String> errors = new ArrayList<>();
-        addIfBlank(errors, nodeId, "node-agent.node-id is required");
         addIfBlank(errors, nodeName, "node-agent.node-name is required");
+        addIfBlank(errors, nodeVersion, "node-agent.node-version is required");
+        addIfBlank(errors, region, "node-agent.region is required");
         addIfBlank(errors, brainBaseUrl, "node-agent.brain-base-url is required");
         addIfBlank(errors, cacheDir, "node-agent.cache-dir is required");
+        if (capacitySlots < 1) {
+            errors.add("node-agent.capacity-slots must be at least 1");
+        }
         if (!errors.isEmpty()) {
             throw new IllegalStateException("Invalid node-agent configuration:\n- " + String.join("\n- ", errors));
         }
@@ -48,6 +59,54 @@ public class NodeConfig {
 
     public void setNodeName(String nodeName) {
         this.nodeName = nodeName;
+    }
+
+    public String getNodeVersion() {
+        return nodeVersion;
+    }
+
+    public void setNodeVersion(String nodeVersion) {
+        this.nodeVersion = nodeVersion;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public int getCapacitySlots() {
+        return capacitySlots;
+    }
+
+    public void setCapacitySlots(int capacitySlots) {
+        this.capacitySlots = capacitySlots;
+    }
+
+    public boolean isDevMode() {
+        return devMode;
+    }
+
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
     }
 
     public String getBrainBaseUrl() {
@@ -82,6 +141,14 @@ public class NodeConfig {
         this.cacheDir = cacheDir;
     }
 
+    public boolean isRegistrationEnabled() {
+        return registrationEnabled;
+    }
+
+    public void setRegistrationEnabled(boolean registrationEnabled) {
+        this.registrationEnabled = registrationEnabled;
+    }
+
     public Auth getAuth() {
         return auth;
     }
@@ -102,6 +169,7 @@ public class NodeConfig {
 
         private String tokenPath;
         private String certPath;
+        private String headerName = "X-Node-Token";
 
         public String getTokenPath() {
             return tokenPath;
@@ -117,6 +185,14 @@ public class NodeConfig {
 
         public void setCertPath(String certPath) {
             this.certPath = certPath;
+        }
+
+        public String getHeaderName() {
+            return headerName;
+        }
+
+        public void setHeaderName(String headerName) {
+            this.headerName = headerName;
         }
     }
 

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeAuthTokenReader.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeAuthTokenReader.java
@@ -1,0 +1,39 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NodeAuthTokenReader {
+
+    private final NodeConfig config;
+
+    public NodeAuthTokenReader(NodeConfig config) {
+        this.config = config;
+    }
+
+    public String readToken() {
+        String tokenPath = config.getAuth().getTokenPath();
+        if (tokenPath == null || tokenPath.isBlank()) {
+            return null;
+        }
+        Path path = Path.of(tokenPath);
+        if (!Files.exists(path)) {
+            throw new NodeRegistrationException("Node auth token file does not exist: " + tokenPath);
+        }
+        try {
+            String token = Files.readString(path, StandardCharsets.UTF_8).trim();
+            if (token.isBlank()) {
+                throw new NodeRegistrationException("Node auth token file is empty: " + tokenPath);
+            }
+            return token;
+        } catch (IOException ex) {
+            throw new NodeRegistrationException("Failed to read node auth token file: " + tokenPath, ex);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationClient.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationClient.java
@@ -1,0 +1,104 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NodeRegistrationClient {
+
+    private static final Timeout CONNECT_TIMEOUT = Timeout.ofSeconds(5);
+    private static final Timeout RESPONSE_TIMEOUT = Timeout.ofSeconds(10);
+
+    private final ObjectMapper objectMapper;
+    private final CloseableHttpClient httpClient;
+
+    public NodeRegistrationClient(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClients.custom()
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(CONNECT_TIMEOUT)
+                        .setResponseTimeout(RESPONSE_TIMEOUT)
+                        .build())
+                .build();
+    }
+
+    public NodeRegistrationResponse register(
+            URI endpoint,
+            String authHeaderName,
+            String authToken,
+            NodeRegistrationRequest request
+    ) {
+        String payload = writePayload(request);
+        HttpPost post = new HttpPost(endpoint);
+        post.setEntity(new StringEntity(payload, ContentType.APPLICATION_JSON));
+        post.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+        post.setHeader(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType());
+        if (authToken != null && !authToken.isBlank()) {
+            post.setHeader(authHeaderName, authToken);
+        }
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            int status = response.getCode();
+            String body = readBody(response);
+            if (status < 200 || status >= 300) {
+                throw new NodeRegistrationException("Registration failed with status " + status + ": " + body);
+            }
+            if (body == null || body.isBlank()) {
+                throw new NodeRegistrationException("Registration response body is empty");
+            }
+            NodeRegistrationResponse registrationResponse =
+                    objectMapper.readValue(body, NodeRegistrationResponse.class);
+            if (registrationResponse.getNodeId() == null) {
+                throw new NodeRegistrationException("Registration response did not include nodeId");
+            }
+            return registrationResponse;
+        } catch (IOException ex) {
+            throw new NodeRegistrationException("Failed to register node at " + endpoint, ex);
+        }
+    }
+
+    private String writePayload(NodeRegistrationRequest request) {
+        try {
+            return objectMapper.writeValueAsString(request);
+        } catch (JsonProcessingException ex) {
+            throw new NodeRegistrationException("Failed to serialize node registration request", ex);
+        }
+    }
+
+    private String readBody(CloseableHttpResponse response) throws IOException {
+        if (response.getEntity() == null) {
+            return "";
+        }
+        try {
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            return body == null ? "" : body.trim();
+        } catch (ParseException ex) {
+            throw new IOException("Failed to parse response body", ex);
+        }
+    }
+
+    @PreDestroy
+    public void close() {
+        try {
+            httpClient.close();
+        } catch (IOException ex) {
+            throw new NodeRegistrationException("Failed to close registration HTTP client", ex);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationException.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationException.java
@@ -1,0 +1,12 @@
+package net.spookly.kodama.nodeagent.registration;
+
+public class NodeRegistrationException extends RuntimeException {
+
+    public NodeRegistrationException(String message) {
+        super(message);
+    }
+
+    public NodeRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRequest.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRequest.java
@@ -1,0 +1,87 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NodeRegistrationRequest {
+
+    private String name;
+    private String region;
+    private int capacitySlots;
+    private String nodeVersion;
+    private boolean devMode;
+    private String tags;
+    private String baseUrl;
+
+    public NodeRegistrationRequest() {
+    }
+
+    public static NodeRegistrationRequest fromConfig(NodeConfig config) {
+        NodeRegistrationRequest request = new NodeRegistrationRequest();
+        request.setName(config.getNodeName());
+        request.setRegion(config.getRegion());
+        request.setCapacitySlots(config.getCapacitySlots());
+        request.setNodeVersion(config.getNodeVersion());
+        request.setDevMode(config.isDevMode());
+        request.setTags(config.getTags());
+        request.setBaseUrl(config.getBaseUrl());
+        return request;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public int getCapacitySlots() {
+        return capacitySlots;
+    }
+
+    public void setCapacitySlots(int capacitySlots) {
+        this.capacitySlots = capacitySlots;
+    }
+
+    public String getNodeVersion() {
+        return nodeVersion;
+    }
+
+    public void setNodeVersion(String nodeVersion) {
+        this.nodeVersion = nodeVersion;
+    }
+
+    public boolean isDevMode() {
+        return devMode;
+    }
+
+    public void setDevMode(boolean devMode) {
+        this.devMode = devMode;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationResponse.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationResponse.java
@@ -1,0 +1,28 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import java.util.UUID;
+
+public class NodeRegistrationResponse {
+
+    private UUID nodeId;
+    private int heartbeatIntervalSeconds;
+
+    public NodeRegistrationResponse() {
+    }
+
+    public UUID getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(UUID nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public int getHeartbeatIntervalSeconds() {
+        return heartbeatIntervalSeconds;
+    }
+
+    public void setHeartbeatIntervalSeconds(int heartbeatIntervalSeconds) {
+        this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRunner.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRunner.java
@@ -1,0 +1,77 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import java.net.URI;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class NodeRegistrationRunner implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(NodeRegistrationRunner.class);
+
+    private final NodeConfig config;
+    private final NodeRegistrationClient registrationClient;
+    private final NodeAuthTokenReader tokenReader;
+    private final NodeRegistrationState registrationState;
+
+    public NodeRegistrationRunner(
+            NodeConfig config,
+            NodeRegistrationClient registrationClient,
+            NodeAuthTokenReader tokenReader,
+            NodeRegistrationState registrationState
+    ) {
+        this.config = config;
+        this.registrationClient = registrationClient;
+        this.tokenReader = tokenReader;
+        this.registrationState = registrationState;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        config.validate();
+        if (!config.isRegistrationEnabled()) {
+            logger.info("Node registration is disabled. Skipping Brain registration.");
+            return;
+        }
+        try {
+            NodeRegistrationRequest request = NodeRegistrationRequest.fromConfig(config);
+            URI endpoint = buildRegistrationEndpoint(config.getBrainBaseUrl());
+            String token = tokenReader.readToken();
+            String headerName = config.getAuth().getHeaderName();
+            if ((token != null && !token.isBlank()) && (headerName == null || headerName.isBlank())) {
+                throw new NodeRegistrationException("Node auth header name is required when a token is provided");
+            }
+            NodeRegistrationResponse response = registrationClient.register(endpoint, headerName, token, request);
+            registrationState.update(response);
+            config.setNodeId(response.getNodeId().toString());
+            logger.info(
+                    "Node registered with Brain. nodeId={}, heartbeatIntervalSeconds={}",
+                    response.getNodeId(),
+                    response.getHeartbeatIntervalSeconds()
+            );
+        } catch (RuntimeException ex) {
+            logger.error("Node registration failed. Shutting down.", ex);
+            throw ex;
+        }
+    }
+
+    private URI buildRegistrationEndpoint(String brainBaseUrl) {
+        if (brainBaseUrl == null || brainBaseUrl.isBlank()) {
+            throw new NodeRegistrationException("Brain base URL is required for registration");
+        }
+        String trimmed = brainBaseUrl.endsWith("/") ? brainBaseUrl.substring(0, brainBaseUrl.length() - 1) : brainBaseUrl;
+        try {
+            return URI.create(trimmed + "/api/nodes/register");
+        } catch (IllegalArgumentException ex) {
+            throw new NodeRegistrationException("Invalid Brain base URL: " + brainBaseUrl, ex);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationState.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationState.java
@@ -1,0 +1,30 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NodeRegistrationState {
+
+    private final AtomicReference<UUID> nodeId = new AtomicReference<>();
+    private final AtomicInteger heartbeatIntervalSeconds = new AtomicInteger();
+
+    public void update(NodeRegistrationResponse response) {
+        if (response == null) {
+            throw new IllegalArgumentException("response is required");
+        }
+        nodeId.set(response.getNodeId());
+        heartbeatIntervalSeconds.set(response.getHeartbeatIntervalSeconds());
+    }
+
+    public UUID getNodeId() {
+        return nodeId.get();
+    }
+
+    public int getHeartbeatIntervalSeconds() {
+        return heartbeatIntervalSeconds.get();
+    }
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -7,11 +7,19 @@ spring:
 node-agent:
   node-id: ${NODE_AGENT_ID:}
   node-name: ${NODE_AGENT_NAME:}
+  node-version: ${NODE_AGENT_NODE_VERSION:}
+  region: ${NODE_AGENT_REGION:}
+  capacity-slots: ${NODE_AGENT_CAPACITY_SLOTS:}
+  dev-mode: ${NODE_AGENT_DEV_MODE:false}
+  tags: ${NODE_AGENT_TAGS:}
+  base-url: ${NODE_AGENT_BASE_URL:}
   brain-base-url: ${NODE_AGENT_BRAIN_BASE_URL:}
+  registration-enabled: ${NODE_AGENT_REGISTRATION_ENABLED:true}
   docker-host: ${NODE_AGENT_DOCKER_HOST:}
   workspace-dir: ${NODE_AGENT_WORKSPACE_DIR:./data}
   cache-dir: ${NODE_AGENT_CACHE_DIR:}
   auth:
+    header-name: ${NODE_AGENT_AUTH_HEADER_NAME:X-Node-Token}
     token-path: ${NODE_AGENT_AUTH_TOKEN_PATH:}
     cert-path: ${NODE_AGENT_AUTH_CERT_PATH:}
   s3:

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/NodeAgentApplicationTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/NodeAgentApplicationTest.java
@@ -8,10 +8,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {
-        "node-agent.node-id=test-node",
         "node-agent.node-name=test-node",
+        "node-agent.node-version=1.0.0",
+        "node-agent.region=local",
+        "node-agent.capacity-slots=4",
         "node-agent.brain-base-url=http://localhost:8080",
-        "node-agent.cache-dir=./cache"
+        "node-agent.cache-dir=./cache",
+        "node-agent.registration-enabled=false"
 })
 class NodeAgentApplicationTest {
 
@@ -20,10 +23,13 @@ class NodeAgentApplicationTest {
 
     @Test
     void loadsConfiguration() {
-        assertThat(config.getNodeId()).isEqualTo("test-node");
         assertThat(config.getNodeName()).isEqualTo("test-node");
+        assertThat(config.getNodeVersion()).isEqualTo("1.0.0");
+        assertThat(config.getRegion()).isEqualTo("local");
+        assertThat(config.getCapacitySlots()).isEqualTo(4);
         assertThat(config.getBrainBaseUrl()).isEqualTo("http://localhost:8080");
         assertThat(config.getCacheDir()).isEqualTo("./cache");
         assertThat(config.getWorkspaceDir()).isEqualTo("./data");
+        assertThat(config.isRegistrationEnabled()).isFalse();
     }
 }

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
@@ -13,17 +13,21 @@ class NodeConfigTest {
 
         assertThatThrownBy(config::validate)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("node-agent.node-id is required")
                 .hasMessageContaining("node-agent.node-name is required")
+                .hasMessageContaining("node-agent.node-version is required")
+                .hasMessageContaining("node-agent.region is required")
                 .hasMessageContaining("node-agent.brain-base-url is required")
-                .hasMessageContaining("node-agent.cache-dir is required");
+                .hasMessageContaining("node-agent.cache-dir is required")
+                .hasMessageContaining("node-agent.capacity-slots must be at least 1");
     }
 
     @Test
     void validateAcceptsRequiredConfig() {
         NodeConfig config = new NodeConfig();
-        config.setNodeId("node-1");
         config.setNodeName("Node 1");
+        config.setNodeVersion("1.0.0");
+        config.setRegion("local");
+        config.setCapacitySlots(4);
         config.setBrainBaseUrl("http://brain:8080");
         config.setCacheDir("./cache");
 

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRequestTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/registration/NodeRegistrationRequestTest.java
@@ -1,0 +1,31 @@
+package net.spookly.kodama.nodeagent.registration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+
+class NodeRegistrationRequestTest {
+
+    @Test
+    void buildsRequestFromNodeConfig() {
+        NodeConfig config = new NodeConfig();
+        config.setNodeName("node-1");
+        config.setNodeVersion("1.2.3");
+        config.setRegion("eu-west");
+        config.setCapacitySlots(12);
+        config.setDevMode(true);
+        config.setTags("gpu,ssd");
+        config.setBaseUrl("http://node-1:9000");
+
+        NodeRegistrationRequest request = NodeRegistrationRequest.fromConfig(config);
+
+        assertThat(request.getName()).isEqualTo("node-1");
+        assertThat(request.getNodeVersion()).isEqualTo("1.2.3");
+        assertThat(request.getRegion()).isEqualTo("eu-west");
+        assertThat(request.getCapacitySlots()).isEqualTo(12);
+        assertThat(request.isDevMode()).isTrue();
+        assertThat(request.getTags()).isEqualTo("gpu,ssd");
+        assertThat(request.getBaseUrl()).isEqualTo("http://node-1:9000");
+    }
+}

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -6,17 +6,26 @@ Describe the configuration inputs for the node agent and how they map to environ
 ## What changed
 - Introduced a typed `NodeConfig` model that binds to `node-agent.*` settings.
 - Added startup validation and a sanitized configuration log line.
+- Added registration-related configuration for Brain startup registration.
 
 ## How to use / impact
 - Configure with environment variables or CLI args (`--node-agent.<key>=...`).
 - Required settings:
-  - `node-agent.node-id` (`NODE_AGENT_ID`)
   - `node-agent.node-name` (`NODE_AGENT_NAME`)
+  - `node-agent.node-version` (`NODE_AGENT_NODE_VERSION`)
+  - `node-agent.region` (`NODE_AGENT_REGION`)
+  - `node-agent.capacity-slots` (`NODE_AGENT_CAPACITY_SLOTS`)
   - `node-agent.brain-base-url` (`NODE_AGENT_BRAIN_BASE_URL`)
   - `node-agent.cache-dir` (`NODE_AGENT_CACHE_DIR`)
 - Optional settings:
+  - `node-agent.node-id` (`NODE_AGENT_ID`, assigned on registration)
+  - `node-agent.dev-mode` (`NODE_AGENT_DEV_MODE`, default `false`)
+  - `node-agent.tags` (`NODE_AGENT_TAGS`)
+  - `node-agent.base-url` (`NODE_AGENT_BASE_URL`)
+  - `node-agent.registration-enabled` (`NODE_AGENT_REGISTRATION_ENABLED`, default `true`)
   - `node-agent.workspace-dir` (`NODE_AGENT_WORKSPACE_DIR`, default `./data`)
   - `node-agent.docker-host` (`NODE_AGENT_DOCKER_HOST`)
+  - `node-agent.auth.header-name` (`NODE_AGENT_AUTH_HEADER_NAME`, default `X-Node-Token`)
   - `node-agent.auth.token-path` (`NODE_AGENT_AUTH_TOKEN_PATH`)
   - `node-agent.auth.cert-path` (`NODE_AGENT_AUTH_CERT_PATH`)
   - `node-agent.s3.endpoint` (`NODE_AGENT_S3_ENDPOINT`)
@@ -24,10 +33,14 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.s3.bucket` (`NODE_AGENT_S3_BUCKET`)
   - `node-agent.s3.access-key` (`NODE_AGENT_S3_ACCESS_KEY`)
   - `node-agent.s3.secret-key` (`NODE_AGENT_S3_SECRET_KEY`)
+- When registration is enabled, the node agent reads the token from `node-agent.auth.token-path`
+  and sends it to the Brain using `node-agent.auth.header-name`.
 
 ## Edge cases / risks
 - Missing required values stops the node agent at startup with a detailed error.
 - Secrets are redacted in startup logs, but the paths to secrets are not.
+- When `node-agent.registration-enabled=true`, failed Brain registration stops the node agent.
+- If `node-agent.auth.token-path` is set but unreadable, registration fails and the node agent stops.
 
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java`

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -7,18 +7,27 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Added a typed `NodeConfig` model for node-agent settings.
 - Added startup validation for required configuration values.
 - Expanded the startup log to include the effective configuration (sans secrets).
+- Added Brain registration on startup and in-memory caching of the assigned node id.
 
 ## How to use / impact
 - Build and run with `./gradlew :node-agent:bootRun` from `backend/`.
 - Configure via environment variables or CLI args (`--node-agent.<key>=...`).
   - Required:
-    - `NODE_AGENT_ID`
     - `NODE_AGENT_NAME`
+    - `NODE_AGENT_NODE_VERSION`
+    - `NODE_AGENT_REGION`
+    - `NODE_AGENT_CAPACITY_SLOTS`
     - `NODE_AGENT_BRAIN_BASE_URL`
     - `NODE_AGENT_CACHE_DIR`
   - Optional:
+    - `NODE_AGENT_ID` (assigned on registration)
+    - `NODE_AGENT_DEV_MODE`
+    - `NODE_AGENT_TAGS`
+    - `NODE_AGENT_BASE_URL`
+    - `NODE_AGENT_REGISTRATION_ENABLED`
     - `NODE_AGENT_WORKSPACE_DIR`
     - `NODE_AGENT_DOCKER_HOST`
+    - `NODE_AGENT_AUTH_HEADER_NAME`
     - `NODE_AGENT_AUTH_TOKEN_PATH`
     - `NODE_AGENT_AUTH_CERT_PATH`
     - `NODE_AGENT_S3_ENDPOINT`
@@ -30,6 +39,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 
 ## Edge cases / risks
 - If required configuration is missing, the node agent will exit on startup with a clear error.
+- If Brain registration fails, the node agent will exit on startup and log the error.
 - The workspace directory is not created automatically yet.
 
 ## Links


### PR DESCRIPTION
## Description
- Add `NodeRegistrationRunner` to handle registration flow at startup.
- Implement `NodeRegistrationClient` for interaction with Brain registration API.
- Introduce `NodeAuthTokenReader` for reading tokens from file system.
- Add `NodeRegistrationRequest`, `NodeRegistrationResponse`, and `NodeRegistrationState` for registration handling.
- Expand `NodeConfig` with registration-related settings and validation.
- Update tests and documentation to reflect new registration functionality.

## Linked Issues
Closes #48

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
