### PR TITLE
feat(#51): implement template cache layout for Node Agent

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheException.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheException.java
@@ -1,0 +1,12 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+public class TemplateCacheException extends RuntimeException {
+
+    public TemplateCacheException(String message) {
+        super(message);
+    }
+
+    public TemplateCacheException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializer.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializer.java
@@ -1,0 +1,42 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+public class TemplateCacheInitializer implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(TemplateCacheInitializer.class);
+
+    private final TemplateCacheLayout layout;
+
+    public TemplateCacheInitializer(TemplateCacheLayout layout) {
+        this.layout = layout;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        ensureCacheDirectories();
+    }
+
+    void ensureCacheDirectories() {
+        try {
+            Files.createDirectories(layout.getTemplatesRoot());
+        } catch (IOException ex) {
+            throw new TemplateCacheException(
+                    "Failed to create template cache directory at " + layout.getTemplatesRoot(),
+                    ex
+            );
+        }
+        logger.info("Template cache directory ready at {}", layout.getTemplatesRoot());
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java
@@ -1,0 +1,81 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateCacheLayout {
+
+    public static final String TEMPLATES_DIR_NAME = "templates";
+    public static final String CONTENTS_DIR_NAME = "contents";
+    public static final String CHECKSUM_FILENAME = "checksum.sha256";
+    public static final String METADATA_FILENAME = "metadata.json";
+
+    private final Path cacheRoot;
+    private final Path templatesRoot;
+
+    public TemplateCacheLayout(NodeConfig config) {
+        if (config == null || config.getCacheDir() == null || config.getCacheDir().isBlank()) {
+            throw new TemplateCacheException("node-agent.cache-dir is required to build template cache layout");
+        }
+        String cacheDir = config.getCacheDir().trim();
+        try {
+            this.cacheRoot = Paths.get(cacheDir).toAbsolutePath().normalize();
+        } catch (InvalidPathException ex) {
+            throw new TemplateCacheException("Invalid node-agent.cache-dir: " + cacheDir, ex);
+        }
+        this.templatesRoot = cacheRoot.resolve(TEMPLATES_DIR_NAME);
+    }
+
+    public Path getCacheRoot() {
+        return cacheRoot;
+    }
+
+    public Path getTemplatesRoot() {
+        return templatesRoot;
+    }
+
+    public TemplateCachePaths resolveTemplateVersion(String templateId, String version) {
+        String normalizedTemplateId = requireSegment("templateId", templateId);
+        String normalizedVersion = requireSegment("version", version);
+        Path templateRoot = templatesRoot.resolve(normalizedTemplateId);
+        Path versionRoot = templateRoot.resolve(normalizedVersion);
+        Path contentsDir = versionRoot.resolve(CONTENTS_DIR_NAME);
+        Path checksumFile = versionRoot.resolve(CHECKSUM_FILENAME);
+        Path metadataFile = versionRoot.resolve(METADATA_FILENAME);
+        return new TemplateCachePaths(
+                normalizedTemplateId,
+                normalizedVersion,
+                templateRoot,
+                versionRoot,
+                contentsDir,
+                checksumFile,
+                metadataFile
+        );
+    }
+
+    private String requireSegment(String label, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        String trimmed = value.trim();
+        Path segment;
+        try {
+            segment = Paths.get(trimmed);
+        } catch (InvalidPathException ex) {
+            throw new IllegalArgumentException(label + " contains invalid path characters", ex);
+        }
+        if (segment.isAbsolute() || segment.getNameCount() != 1) {
+            throw new IllegalArgumentException(label + " must be a single path segment");
+        }
+        String name = segment.getFileName().toString();
+        if (".".equals(name) || "..".equals(name)) {
+            throw new IllegalArgumentException(label + " must not be '.' or '..'");
+        }
+        return name;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCachePaths.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCachePaths.java
@@ -1,0 +1,14 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.nio.file.Path;
+
+public record TemplateCachePaths(
+        String templateId,
+        String version,
+        Path templateRoot,
+        Path versionRoot,
+        Path contentsDir,
+        Path checksumFile,
+        Path metadataFile
+) {
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -18,7 +18,7 @@ node-agent:
   heartbeat-interval-seconds: ${NODE_AGENT_HEARTBEAT_INTERVAL_SECONDS:0}
   docker-host: ${NODE_AGENT_DOCKER_HOST:}
   workspace-dir: ${NODE_AGENT_WORKSPACE_DIR:./data}
-  cache-dir: ${NODE_AGENT_CACHE_DIR:}
+  cache-dir: ${NODE_AGENT_CACHE_DIR:./cache}
   auth:
     header-name: ${NODE_AGENT_AUTH_HEADER_NAME:X-Node-Token}
     token-path: ${NODE_AGENT_AUTH_TOKEN_PATH:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializerTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializerTest.java
@@ -1,0 +1,30 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.DefaultApplicationArguments;
+
+class TemplateCacheInitializerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createsCacheDirectoriesOnStartup() {
+        NodeConfig config = new NodeConfig();
+        config.setCacheDir(tempDir.resolve("cache-root").toString());
+
+        TemplateCacheLayout layout = new TemplateCacheLayout(config);
+        TemplateCacheInitializer initializer = new TemplateCacheInitializer(layout);
+
+        initializer.run(new DefaultApplicationArguments(new String[0]));
+
+        assertThat(Files.isDirectory(layout.getTemplatesRoot())).isTrue();
+    }
+}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayoutTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayoutTest.java
@@ -1,0 +1,50 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TemplateCacheLayoutTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolvesTemplateVersionPaths() {
+        NodeConfig config = new NodeConfig();
+        config.setCacheDir(tempDir.resolve("cache-root").toString());
+
+        TemplateCacheLayout layout = new TemplateCacheLayout(config);
+        TemplateCachePaths paths = layout.resolveTemplateVersion("starter", "1.2.3");
+
+        Path expectedVersionRoot = layout.getTemplatesRoot().resolve("starter").resolve("1.2.3");
+
+        assertThat(paths.templateId()).isEqualTo("starter");
+        assertThat(paths.version()).isEqualTo("1.2.3");
+        assertThat(paths.templateRoot()).isEqualTo(layout.getTemplatesRoot().resolve("starter"));
+        assertThat(paths.versionRoot()).isEqualTo(expectedVersionRoot);
+        assertThat(paths.contentsDir()).isEqualTo(expectedVersionRoot.resolve("contents"));
+        assertThat(paths.checksumFile()).isEqualTo(expectedVersionRoot.resolve("checksum.sha256"));
+        assertThat(paths.metadataFile()).isEqualTo(expectedVersionRoot.resolve("metadata.json"));
+    }
+
+    @Test
+    void rejectsInvalidSegments() {
+        NodeConfig config = new NodeConfig();
+        config.setCacheDir(tempDir.resolve("cache-root").toString());
+
+        TemplateCacheLayout layout = new TemplateCacheLayout(config);
+
+        assertThatThrownBy(() -> layout.resolveTemplateVersion("../escape", "1.0"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("templateId");
+        assertThatThrownBy(() -> layout.resolveTemplateVersion("starter", "../1.0"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("version");
+    }
+}

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -40,6 +40,8 @@ Describe the configuration inputs for the node agent and how they map to environ
   and sends it to the Brain using `node-agent.auth.header-name`.
 - When `node-agent.heartbeat-interval-seconds` is `0`, the node agent uses the heartbeat interval
   provided by the Brain during registration.
+- `node-agent.cache-dir` is the root for template cache storage. The node agent creates a
+  `templates/` subdirectory on startup. See `docs/node/operations/template-cache.md` for the layout.
 - S3 configuration is required for template storage. When `node-agent.s3.endpoint` is set, the client
   uses path-style requests for local or custom S3 endpoints.
 

--- a/docs/node/operations/template-cache.md
+++ b/docs/node/operations/template-cache.md
@@ -1,0 +1,25 @@
+# Template Cache Layout
+
+## Purpose
+Define where the node agent stores cached templates and how cache paths are resolved.
+
+## What changed
+- Added a deterministic cache directory layout rooted at `node-agent.cache-dir`.
+- Created the template cache root on startup before any downloads occur.
+
+## How to use / impact
+- The node agent creates `<cacheDir>/templates` on startup.
+- For each template version, the layout is:
+  - `<cacheDir>/templates/<templateId>/<version>/contents/` (extracted files)
+  - `<cacheDir>/templates/<templateId>/<version>/checksum.sha256` (checksum marker)
+  - `<cacheDir>/templates/<templateId>/<version>/metadata.json` (metadata marker)
+- Use `TemplateCacheLayout.resolveTemplateVersion(templateId, version)` to resolve paths.
+
+## Edge cases / risks
+- `templateId` and `version` must be single path segments (no slashes or `..`).
+- Invalid cache paths or permission failures stop the node agent at startup.
+
+## Links
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializer.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java`


### PR DESCRIPTION
## Description
- Introduced directory structure for caching templates under `node-agent.cache-dir`.
- Added `TemplateCacheInitializer` to ensure cache directories are created at startup.
- Created `TemplateCacheLayout` for resolving template version paths.
- Updated configuration defaults and documentation for template caching.

## Linked Issues
Closes #51

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
