### PR TITLE
feat(#52): add template cache lookup and validation support

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
@@ -24,6 +24,7 @@ public class NodeConfig {
     private int heartbeatIntervalSeconds;
     private Auth auth = new Auth();
     private S3 s3 = new S3();
+    private TemplateCacheCheck templateCacheCheck = new TemplateCacheCheck();
 
     public void validate() {
         List<String> errors = new ArrayList<>();
@@ -37,6 +38,11 @@ public class NodeConfig {
         }
         if (heartbeatIntervalSeconds < 0) {
             errors.add("node-agent.heartbeat-interval-seconds must be 0 or greater");
+        }
+        if (templateCacheCheck != null && templateCacheCheck.isEnabled()) {
+            addIfBlank(errors, templateCacheCheck.getTemplateId(), "node-agent.template-cache-check.template-id is required");
+            addIfBlank(errors, templateCacheCheck.getVersion(), "node-agent.template-cache-check.version is required");
+            addIfBlank(errors, templateCacheCheck.getChecksum(), "node-agent.template-cache-check.checksum is required");
         }
         if (!errors.isEmpty()) {
             throw new IllegalStateException("Invalid node-agent configuration:\n- " + String.join("\n- ", errors));
@@ -177,6 +183,14 @@ public class NodeConfig {
         this.s3 = s3 == null ? new S3() : s3;
     }
 
+    public TemplateCacheCheck getTemplateCacheCheck() {
+        return templateCacheCheck;
+    }
+
+    public void setTemplateCacheCheck(TemplateCacheCheck templateCacheCheck) {
+        this.templateCacheCheck = templateCacheCheck == null ? new TemplateCacheCheck() : templateCacheCheck;
+    }
+
     public static class Auth {
 
         private String tokenPath;
@@ -254,6 +268,46 @@ public class NodeConfig {
 
         public void setSecretKey(String secretKey) {
             this.secretKey = secretKey;
+        }
+    }
+
+    public static class TemplateCacheCheck {
+
+        private boolean enabled;
+        private String templateId;
+        private String version;
+        private String checksum;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(String templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getChecksum() {
+            return checksum;
+        }
+
+        public void setChecksum(String checksum) {
+            this.checksum = checksum;
         }
     }
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheCheckRunner.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheCheckRunner.java
@@ -1,0 +1,47 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 2)
+public class TemplateCacheCheckRunner implements ApplicationRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(TemplateCacheCheckRunner.class);
+
+    private final NodeConfig config;
+    private final TemplateCacheLookupService lookupService;
+
+    public TemplateCacheCheckRunner(NodeConfig config, TemplateCacheLookupService lookupService) {
+        this.config = config;
+        this.lookupService = lookupService;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        NodeConfig.TemplateCacheCheck check = config.getTemplateCacheCheck();
+        if (check == null || !check.isEnabled()) {
+            return;
+        }
+
+        TemplateCacheLookupResult result = lookupService.findCachedTemplate(
+                check.getTemplateId(),
+                check.getVersion(),
+                check.getChecksum()
+        );
+
+        logger.info(
+                "Template cache check completed. templateId={}, version={}, hit={}, reason={}",
+                result.templateId(),
+                result.version(),
+                result.isCacheHit(),
+                result.missReason()
+        );
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupResult.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupResult.java
@@ -1,0 +1,54 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.nio.file.Path;
+
+public record TemplateCacheLookupResult(
+        String templateId,
+        String version,
+        String expectedChecksum,
+        boolean isCacheHit,
+        TemplateCacheMissReason missReason,
+        Path contentsDir,
+        String cachedChecksum
+) {
+
+    public static TemplateCacheLookupResult hit(
+            String templateId,
+            String version,
+            String expectedChecksum,
+            Path contentsDir,
+            String cachedChecksum
+    ) {
+        return new TemplateCacheLookupResult(
+                templateId,
+                version,
+                expectedChecksum,
+                true,
+                null,
+                contentsDir,
+                cachedChecksum
+        );
+    }
+
+    public static TemplateCacheLookupResult miss(
+            String templateId,
+            String version,
+            String expectedChecksum,
+            TemplateCacheMissReason reason,
+            Path contentsDir,
+            String cachedChecksum
+    ) {
+        if (reason == null) {
+            throw new IllegalArgumentException("reason is required for a cache miss");
+        }
+        return new TemplateCacheLookupResult(
+                templateId,
+                version,
+                expectedChecksum,
+                false,
+                reason,
+                contentsDir,
+                cachedChecksum
+        );
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupService.java
@@ -1,0 +1,94 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateCacheLookupService {
+
+    private static final Logger logger = LoggerFactory.getLogger(TemplateCacheLookupService.class);
+
+    private final TemplateCacheLayout layout;
+
+    public TemplateCacheLookupService(TemplateCacheLayout layout) {
+        this.layout = layout;
+    }
+
+    public TemplateCacheLookupResult findCachedTemplate(String templateId, String version, String expectedChecksum) {
+        String normalizedExpected = requireChecksum(expectedChecksum);
+        TemplateCachePaths paths = layout.resolveTemplateVersion(templateId, version);
+
+        if (!Files.isDirectory(paths.contentsDir()) || !Files.isRegularFile(paths.checksumFile())) {
+            TemplateCacheLookupResult result = TemplateCacheLookupResult.miss(
+                    paths.templateId(),
+                    paths.version(),
+                    normalizedExpected,
+                    TemplateCacheMissReason.NOT_FOUND,
+                    paths.contentsDir(),
+                    null
+            );
+            logger.info(
+                    "Template cache miss. templateId={}, version={}, reason={}",
+                    paths.templateId(),
+                    paths.version(),
+                    result.missReason()
+            );
+            return result;
+        }
+
+        String cachedChecksum = readChecksum(paths.checksumFile());
+        if (!cachedChecksum.equals(normalizedExpected)) {
+            TemplateCacheLookupResult result = TemplateCacheLookupResult.miss(
+                    paths.templateId(),
+                    paths.version(),
+                    normalizedExpected,
+                    TemplateCacheMissReason.CHECKSUM_MISMATCH,
+                    paths.contentsDir(),
+                    cachedChecksum
+            );
+            logger.info(
+                    "Template cache miss. templateId={}, version={}, reason={}, cachedChecksum={}",
+                    paths.templateId(),
+                    paths.version(),
+                    result.missReason(),
+                    cachedChecksum
+            );
+            return result;
+        }
+
+        TemplateCacheLookupResult result = TemplateCacheLookupResult.hit(
+                paths.templateId(),
+                paths.version(),
+                normalizedExpected,
+                paths.contentsDir(),
+                cachedChecksum
+        );
+        logger.info(
+                "Template cache hit. templateId={}, version={}",
+                paths.templateId(),
+                paths.version()
+        );
+        return result;
+    }
+
+    private String requireChecksum(String expectedChecksum) {
+        if (expectedChecksum == null || expectedChecksum.isBlank()) {
+            throw new IllegalArgumentException("expectedChecksum is required");
+        }
+        return expectedChecksum.trim();
+    }
+
+    private String readChecksum(Path checksumFile) {
+        try {
+            return Files.readString(checksumFile, StandardCharsets.UTF_8).trim();
+        } catch (IOException ex) {
+            throw new TemplateCacheException("Failed to read checksum file at " + checksumFile, ex);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheMissReason.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheMissReason.java
@@ -1,0 +1,6 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+public enum TemplateCacheMissReason {
+    NOT_FOUND,
+    CHECKSUM_MISMATCH
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -19,6 +19,11 @@ node-agent:
   docker-host: ${NODE_AGENT_DOCKER_HOST:}
   workspace-dir: ${NODE_AGENT_WORKSPACE_DIR:./data}
   cache-dir: ${NODE_AGENT_CACHE_DIR:./cache}
+  template-cache-check:
+    enabled: ${NODE_AGENT_TEMPLATE_CACHE_CHECK_ENABLED:false}
+    template-id: ${NODE_AGENT_TEMPLATE_CACHE_CHECK_TEMPLATE_ID:}
+    version: ${NODE_AGENT_TEMPLATE_CACHE_CHECK_VERSION:}
+    checksum: ${NODE_AGENT_TEMPLATE_CACHE_CHECK_CHECKSUM:}
   auth:
     header-name: ${NODE_AGENT_AUTH_HEADER_NAME:X-Node-Token}
     token-path: ${NODE_AGENT_AUTH_TOKEN_PATH:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
@@ -49,4 +49,39 @@ class NodeConfigTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("node-agent.heartbeat-interval-seconds must be 0 or greater");
     }
+
+    @Test
+    void validateRejectsTemplateCacheCheckWhenMissingFields() {
+        NodeConfig config = new NodeConfig();
+        config.setNodeName("Node 1");
+        config.setNodeVersion("1.0.0");
+        config.setRegion("local");
+        config.setCapacitySlots(4);
+        config.setBrainBaseUrl("http://brain:8080");
+        config.setCacheDir("./cache");
+        config.getTemplateCacheCheck().setEnabled(true);
+
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("node-agent.template-cache-check.template-id is required")
+                .hasMessageContaining("node-agent.template-cache-check.version is required")
+                .hasMessageContaining("node-agent.template-cache-check.checksum is required");
+    }
+
+    @Test
+    void validateAcceptsTemplateCacheCheckWhenConfigured() {
+        NodeConfig config = new NodeConfig();
+        config.setNodeName("Node 1");
+        config.setNodeVersion("1.0.0");
+        config.setRegion("local");
+        config.setCapacitySlots(4);
+        config.setBrainBaseUrl("http://brain:8080");
+        config.setCacheDir("./cache");
+        config.getTemplateCacheCheck().setEnabled(true);
+        config.getTemplateCacheCheck().setTemplateId("starter");
+        config.getTemplateCacheCheck().setVersion("1.2.3");
+        config.getTemplateCacheCheck().setChecksum("abc123");
+
+        assertThatNoException().isThrownBy(config::validate);
+    }
 }

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupServiceTest.java
@@ -1,0 +1,108 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TemplateCacheLookupServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void returnsHitWhenChecksumMatches() throws Exception {
+        TemplateCacheLookupService service = createService();
+        TemplateCacheLayout layout = createLayout();
+        TemplateCachePaths paths = layout.resolveTemplateVersion("starter", "1.2.3");
+
+        Files.createDirectories(paths.contentsDir());
+        Files.writeString(paths.checksumFile(), "abc123\n");
+
+        TemplateCacheLookupResult result = service.findCachedTemplate("starter", "1.2.3", "abc123");
+
+        assertThat(result.isCacheHit()).isTrue();
+        assertThat(result.missReason()).isNull();
+        assertThat(result.contentsDir()).isEqualTo(paths.contentsDir());
+        assertThat(result.cachedChecksum()).isEqualTo("abc123");
+    }
+
+    @Test
+    void returnsMissWhenChecksumDiffers() throws Exception {
+        TemplateCacheLookupService service = createService();
+        TemplateCacheLayout layout = createLayout();
+        TemplateCachePaths paths = layout.resolveTemplateVersion("starter", "1.2.3");
+
+        Files.createDirectories(paths.contentsDir());
+        Files.writeString(paths.checksumFile(), "abc123");
+
+        TemplateCacheLookupResult result = service.findCachedTemplate("starter", "1.2.3", "def456");
+
+        assertThat(result.isCacheHit()).isFalse();
+        assertThat(result.missReason()).isEqualTo(TemplateCacheMissReason.CHECKSUM_MISMATCH);
+        assertThat(result.cachedChecksum()).isEqualTo("abc123");
+    }
+
+    @Test
+    void returnsMissWhenCacheEntryIsMissing() {
+        TemplateCacheLookupService service = createService();
+
+        TemplateCacheLookupResult result = service.findCachedTemplate("starter", "1.2.3", "abc123");
+
+        assertThat(result.isCacheHit()).isFalse();
+        assertThat(result.missReason()).isEqualTo(TemplateCacheMissReason.NOT_FOUND);
+    }
+
+    @Test
+    void returnsMissWhenChecksumFileIsMissing() throws Exception {
+        TemplateCacheLookupService service = createService();
+        TemplateCacheLayout layout = createLayout();
+        TemplateCachePaths paths = layout.resolveTemplateVersion("starter", "1.2.3");
+
+        Files.createDirectories(paths.contentsDir());
+
+        TemplateCacheLookupResult result = service.findCachedTemplate("starter", "1.2.3", "abc123");
+
+        assertThat(result.isCacheHit()).isFalse();
+        assertThat(result.missReason()).isEqualTo(TemplateCacheMissReason.NOT_FOUND);
+    }
+
+    @Test
+    void returnsMissWhenContentsDirIsMissing() throws Exception {
+        TemplateCacheLookupService service = createService();
+        TemplateCacheLayout layout = createLayout();
+        TemplateCachePaths paths = layout.resolveTemplateVersion("starter", "1.2.3");
+
+        Files.createDirectories(paths.versionRoot());
+        Files.writeString(paths.checksumFile(), "abc123");
+
+        TemplateCacheLookupResult result = service.findCachedTemplate("starter", "1.2.3", "abc123");
+
+        assertThat(result.isCacheHit()).isFalse();
+        assertThat(result.missReason()).isEqualTo(TemplateCacheMissReason.NOT_FOUND);
+    }
+
+    @Test
+    void rejectsBlankExpectedChecksum() {
+        TemplateCacheLookupService service = createService();
+
+        assertThatThrownBy(() -> service.findCachedTemplate("starter", "1.2.3", " "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expectedChecksum");
+    }
+
+    private TemplateCacheLookupService createService() {
+        return new TemplateCacheLookupService(createLayout());
+    }
+
+    private TemplateCacheLayout createLayout() {
+        NodeConfig config = new NodeConfig();
+        config.setCacheDir(tempDir.resolve("cache-root").toString());
+        return new TemplateCacheLayout(config);
+    }
+}

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -9,6 +9,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - Added registration-related configuration for Brain startup registration.
 - Added a heartbeat interval override for node-agent heartbeats.
 - Added S3-backed template storage configuration for fetching template tarballs.
+- Added optional template cache check inputs for manual cache validation at startup.
 
 ## How to use / impact
 - Configure with environment variables or CLI args (`--node-agent.<key>=...`).
@@ -32,6 +33,10 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.heartbeat-interval-seconds` (`NODE_AGENT_HEARTBEAT_INTERVAL_SECONDS`, default `0`)
   - `node-agent.workspace-dir` (`NODE_AGENT_WORKSPACE_DIR`, default `./data`)
   - `node-agent.docker-host` (`NODE_AGENT_DOCKER_HOST`)
+  - `node-agent.template-cache-check.enabled` (`NODE_AGENT_TEMPLATE_CACHE_CHECK_ENABLED`, default `false`)
+  - `node-agent.template-cache-check.template-id` (`NODE_AGENT_TEMPLATE_CACHE_CHECK_TEMPLATE_ID`)
+  - `node-agent.template-cache-check.version` (`NODE_AGENT_TEMPLATE_CACHE_CHECK_VERSION`)
+  - `node-agent.template-cache-check.checksum` (`NODE_AGENT_TEMPLATE_CACHE_CHECK_CHECKSUM`)
   - `node-agent.auth.header-name` (`NODE_AGENT_AUTH_HEADER_NAME`, default `X-Node-Token`)
   - `node-agent.auth.token-path` (`NODE_AGENT_AUTH_TOKEN_PATH`)
   - `node-agent.auth.cert-path` (`NODE_AGENT_AUTH_CERT_PATH`)
@@ -42,6 +47,8 @@ Describe the configuration inputs for the node agent and how they map to environ
   provided by the Brain during registration.
 - `node-agent.cache-dir` is the root for template cache storage. The node agent creates a
   `templates/` subdirectory on startup. See `docs/node/operations/template-cache.md` for the layout.
+- When `node-agent.template-cache-check.enabled=true`, the node agent validates a single cached
+  template at startup and logs the cache hit/miss outcome.
 - S3 configuration is required for template storage. When `node-agent.s3.endpoint` is set, the client
   uses path-style requests for local or custom S3 endpoints.
 
@@ -50,6 +57,8 @@ Describe the configuration inputs for the node agent and how they map to environ
 - Secrets are redacted in startup logs, but the paths to secrets are not.
 - When `node-agent.registration-enabled=true`, failed Brain registration stops the node agent.
 - If `node-agent.auth.token-path` is set but unreadable, registration fails and the node agent stops.
+- When `node-agent.template-cache-check.enabled=true`, missing template-id/version/checksum values
+  stop the node agent at startup.
 - Missing or invalid S3 settings stop the node agent when template storage is initialized.
 
 ## Links

--- a/docs/node/operations/template-cache.md
+++ b/docs/node/operations/template-cache.md
@@ -6,6 +6,8 @@ Define where the node agent stores cached templates and how cache paths are reso
 ## What changed
 - Added a deterministic cache directory layout rooted at `node-agent.cache-dir`.
 - Created the template cache root on startup before any downloads occur.
+- Added cache lookup that validates cached template checksums before reuse.
+- Added an optional startup cache check for manually seeded cache entries.
 
 ## How to use / impact
 - The node agent creates `<cacheDir>/templates` on startup.
@@ -14,12 +16,21 @@ Define where the node agent stores cached templates and how cache paths are reso
   - `<cacheDir>/templates/<templateId>/<version>/checksum.sha256` (checksum marker)
   - `<cacheDir>/templates/<templateId>/<version>/metadata.json` (metadata marker)
 - Use `TemplateCacheLayout.resolveTemplateVersion(templateId, version)` to resolve paths.
+- Write the expected checksum (hex string) into `checksum.sha256`. Whitespace is trimmed on read.
+- Use `TemplateCacheLookupService.findCachedTemplate(templateId, version, expectedChecksum)` to validate a cache entry.
+  - Returns `NOT_FOUND` when the contents directory or checksum file is missing.
+  - Returns `CHECKSUM_MISMATCH` when the stored checksum differs.
+- For manual validation at startup, set `node-agent.template-cache-check.*` to trigger a single
+  cache lookup and log the hit/miss decision.
 
 ## Edge cases / risks
 - `templateId` and `version` must be single path segments (no slashes or `..`).
 - Invalid cache paths or permission failures stop the node agent at startup.
+- Unreadable checksum files throw `TemplateCacheException` and should be treated as cache errors.
 
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java`
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheInitializer.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupService.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLookupResult.java`
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java`


### PR DESCRIPTION
## Description
- Implemented `TemplateCacheLookupService` for validating cached templates based on checksum.
- Added `TemplateCacheLookupResult` and `TemplateCacheMissReason` for result handling.
- Introduced optional startup template cache check via configuration.
- Updated `NodeConfig` validation to ensure required fields are set for cache checks.
- Enhanced documentation with details for cache validation and startup usage.

## Linked Issues
Closes #52

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
