### PR TITLE
feat(#54): add cache purge functionality with API support

### DIFF
--- a/backend/node-agent/build.gradle
+++ b/backend/node-agent/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(':common')
 
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheLayout.java
@@ -39,6 +39,11 @@ public class TemplateCacheLayout {
         return templatesRoot;
     }
 
+    public Path resolveTemplateRoot(String templateId) {
+        String normalizedTemplateId = requireSegment("templateId", templateId);
+        return templatesRoot.resolve(normalizedTemplateId);
+    }
+
     public TemplateCachePaths resolveTemplateVersion(String templateId, String version) {
         String normalizedTemplateId = requireSegment("templateId", templateId);
         String normalizedVersion = requireSegment("version", version);

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheManager.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheManager.java
@@ -1,0 +1,149 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemplateCacheManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(TemplateCacheManager.class);
+
+    private final TemplateCacheLayout layout;
+
+    public TemplateCacheManager(TemplateCacheLayout layout) {
+        this.layout = Objects.requireNonNull(layout, "layout");
+    }
+
+    public TemplateCachePurgeResult purgeAll() {
+        Path templatesRoot = layout.getTemplatesRoot();
+        ensureTemplatesRoot(templatesRoot);
+        TemplateCachePurgeResult total = new TemplateCachePurgeResult(0, 0, 0);
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(templatesRoot)) {
+            for (Path child : stream) {
+                ensureWithinTemplatesRoot(templatesRoot, child);
+                TemplateCachePurgeResult result = deleteRecursively(child);
+                total = total.add(result);
+            }
+        } catch (IOException ex) {
+            throw new TemplateCacheException("Failed to purge template cache under " + templatesRoot, ex);
+        }
+        logger.info(
+                "Template cache purge completed. scope=all removedFiles={} removedDirectories={} removedBytes={}",
+                total.deletedFiles(),
+                total.deletedDirectories(),
+                total.deletedBytes()
+        );
+        return total;
+    }
+
+    public TemplateCachePurgeResult purgeTemplate(String templateId) {
+        String normalizedTemplateId = requireTemplateId(templateId);
+        Path templatesRoot = layout.getTemplatesRoot();
+        ensureTemplatesRoot(templatesRoot);
+        Path templateRoot = layout.resolveTemplateRoot(normalizedTemplateId);
+        ensureWithinTemplatesRoot(templatesRoot, templateRoot);
+        TemplateCachePurgeResult result = deleteRecursively(templateRoot);
+        logger.info(
+                "Template cache purge completed. scope=template templateId={} removedFiles={} removedDirectories={} removedBytes={}",
+                normalizedTemplateId,
+                result.deletedFiles(),
+                result.deletedDirectories(),
+                result.deletedBytes()
+        );
+        return result;
+    }
+
+    private void ensureTemplatesRoot(Path templatesRoot) {
+        try {
+            Files.createDirectories(templatesRoot);
+        } catch (IOException ex) {
+            throw new TemplateCacheException("Failed to ensure template cache directory at " + templatesRoot, ex);
+        }
+    }
+
+    private TemplateCachePurgeResult deleteRecursively(Path root) {
+        if (root == null || !Files.exists(root)) {
+            return new TemplateCachePurgeResult(0, 0, 0);
+        }
+        ensureWithinTemplatesRoot(layout.getTemplatesRoot(), root);
+        PurgeAccumulator accumulator = new PurgeAccumulator();
+        try {
+            Files.walkFileTree(root, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    long size = attrs == null ? safeSize(file) : attrs.size();
+                    Files.deleteIfExists(file);
+                    accumulator.addFile(size);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    Files.deleteIfExists(dir);
+                    accumulator.addDirectory();
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ex) {
+            throw new TemplateCacheException("Failed to delete cache path " + root, ex);
+        }
+        return accumulator.toResult();
+    }
+
+    private long safeSize(Path file) throws IOException {
+        return Files.isRegularFile(file) ? Files.size(file) : 0L;
+    }
+
+    private void ensureWithinTemplatesRoot(Path templatesRoot, Path candidate) {
+        if (templatesRoot == null || candidate == null) {
+            throw new TemplateCacheException("Template cache purge path cannot be null");
+        }
+        Path normalizedRoot = templatesRoot.toAbsolutePath().normalize();
+        Path normalizedCandidate = candidate.toAbsolutePath().normalize();
+        if (!normalizedCandidate.startsWith(normalizedRoot)) {
+            throw new TemplateCacheException(
+                    "Refusing to delete path outside template cache root. root=" + normalizedRoot + " path=" + normalizedCandidate
+            );
+        }
+    }
+
+    private String requireTemplateId(String templateId) {
+        if (templateId == null || templateId.isBlank()) {
+            throw new IllegalArgumentException("templateId is required");
+        }
+        return templateId.trim();
+    }
+
+    private static final class PurgeAccumulator {
+
+        private long deletedFiles;
+        private long deletedDirectories;
+        private long deletedBytes;
+
+        void addFile(long size) {
+            deletedFiles++;
+            deletedBytes += Math.max(0L, size);
+        }
+
+        void addDirectory() {
+            deletedDirectories++;
+        }
+
+        TemplateCachePurgeResult toResult() {
+            return new TemplateCachePurgeResult(deletedFiles, deletedDirectories, deletedBytes);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCachePurgeResult.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/cache/TemplateCachePurgeResult.java
@@ -1,0 +1,15 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+public record TemplateCachePurgeResult(long deletedFiles, long deletedDirectories, long deletedBytes) {
+
+    public TemplateCachePurgeResult add(TemplateCachePurgeResult other) {
+        if (other == null) {
+            return this;
+        }
+        return new TemplateCachePurgeResult(
+                deletedFiles + other.deletedFiles(),
+                deletedDirectories + other.deletedDirectories(),
+                deletedBytes + other.deletedBytes()
+        );
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/controller/TemplateCacheController.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/controller/TemplateCacheController.java
@@ -1,0 +1,43 @@
+package net.spookly.kodama.nodeagent.template.controller;
+
+import net.spookly.kodama.nodeagent.template.cache.TemplateCacheManager;
+import net.spookly.kodama.nodeagent.template.cache.TemplateCachePurgeResult;
+import net.spookly.kodama.nodeagent.template.dto.TemplateCachePurgeRequest;
+import net.spookly.kodama.nodeagent.template.dto.TemplateCachePurgeResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/cache")
+public class TemplateCacheController {
+
+    private final TemplateCacheManager cacheManager;
+
+    public TemplateCacheController(TemplateCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @PostMapping("/purge")
+    @ResponseStatus(HttpStatus.OK)
+    public TemplateCachePurgeResponse purge(@RequestBody(required = false) TemplateCachePurgeRequest request) {
+        String templateId = request == null ? null : request.templateId();
+        if (templateId != null && templateId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "templateId must not be blank");
+        }
+        try {
+            if (templateId == null) {
+                TemplateCachePurgeResult result = cacheManager.purgeAll();
+                return TemplateCachePurgeResponse.forAll(result);
+            }
+            TemplateCachePurgeResult result = cacheManager.purgeTemplate(templateId);
+            return TemplateCachePurgeResponse.forTemplate(templateId.trim(), result);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/dto/TemplateCachePurgeRequest.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/dto/TemplateCachePurgeRequest.java
@@ -1,0 +1,4 @@
+package net.spookly.kodama.nodeagent.template.dto;
+
+public record TemplateCachePurgeRequest(String templateId) {
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/dto/TemplateCachePurgeResponse.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/template/dto/TemplateCachePurgeResponse.java
@@ -1,0 +1,37 @@
+package net.spookly.kodama.nodeagent.template.dto;
+
+import net.spookly.kodama.nodeagent.template.cache.TemplateCachePurgeResult;
+
+public record TemplateCachePurgeResponse(
+        String scope,
+        String templateId,
+        long deletedFiles,
+        long deletedDirectories,
+        long deletedBytes
+) {
+
+    public static TemplateCachePurgeResponse forAll(TemplateCachePurgeResult result) {
+        return fromResult("all", null, result);
+    }
+
+    public static TemplateCachePurgeResponse forTemplate(String templateId, TemplateCachePurgeResult result) {
+        return fromResult("template", templateId, result);
+    }
+
+    private static TemplateCachePurgeResponse fromResult(
+            String scope,
+            String templateId,
+            TemplateCachePurgeResult result
+    ) {
+        TemplateCachePurgeResult safeResult = result == null
+                ? new TemplateCachePurgeResult(0, 0, 0)
+                : result;
+        return new TemplateCachePurgeResponse(
+                scope,
+                templateId,
+                safeResult.deletedFiles(),
+                safeResult.deletedDirectories(),
+                safeResult.deletedBytes()
+        );
+    }
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: kodama-node-agent
-  main:
-    web-application-type: none
 
 node-agent:
   node-id: ${NODE_AGENT_ID:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheManagerTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/template/cache/TemplateCacheManagerTest.java
@@ -1,0 +1,81 @@
+package net.spookly.kodama.nodeagent.template.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TemplateCacheManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void purgeAllRemovesAllTemplatesAndPreservesRoot() throws Exception {
+        TemplateCacheLayout layout = createLayout();
+        TemplateCacheManager manager = new TemplateCacheManager(layout);
+
+        createTemplateVersion(layout, "starter", "1.0.0", "abc", "1234");
+        createTemplateVersion(layout, "survival", "2.0.0", "hello", "world");
+
+        TemplateCachePurgeResult result = manager.purgeAll();
+
+        assertThat(result.deletedFiles()).isEqualTo(4);
+        assertThat(result.deletedDirectories()).isEqualTo(6);
+        assertThat(result.deletedBytes()).isEqualTo(5 + 5 + 3 + 4);
+        assertThat(Files.exists(layout.getTemplatesRoot())).isTrue();
+        try (var stream = Files.list(layout.getTemplatesRoot())) {
+            assertThat(stream.count()).isZero();
+        }
+    }
+
+    @Test
+    void purgeTemplateRemovesOnlyRequestedTemplate() throws Exception {
+        TemplateCacheLayout layout = createLayout();
+        TemplateCacheManager manager = new TemplateCacheManager(layout);
+
+        createTemplateVersion(layout, "starter", "1.0.0", "abc", "1234");
+        createTemplateVersion(layout, "survival", "2.0.0", "hello", "world");
+
+        TemplateCachePurgeResult result = manager.purgeTemplate("starter");
+
+        assertThat(result.deletedFiles()).isEqualTo(2);
+        assertThat(result.deletedDirectories()).isEqualTo(3);
+        assertThat(result.deletedBytes()).isEqualTo(3 + 4);
+        assertThat(Files.exists(layout.resolveTemplateRoot("starter"))).isFalse();
+        assertThat(Files.exists(layout.resolveTemplateRoot("survival"))).isTrue();
+    }
+
+    @Test
+    void purgeTemplateRejectsInvalidTemplateId() {
+        TemplateCacheManager manager = new TemplateCacheManager(createLayout());
+
+        assertThatThrownBy(() -> manager.purgeTemplate("../escape"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("templateId");
+    }
+
+    private TemplateCacheLayout createLayout() {
+        NodeConfig config = new NodeConfig();
+        config.setCacheDir(tempDir.resolve("cache-root").toString());
+        return new TemplateCacheLayout(config);
+    }
+
+    private void createTemplateVersion(
+            TemplateCacheLayout layout,
+            String templateId,
+            String version,
+            String firstFileContent,
+            String secondFileContent
+    ) throws Exception {
+        TemplateCachePaths paths = layout.resolveTemplateVersion(templateId, version);
+        Files.createDirectories(paths.contentsDir());
+        Files.writeString(paths.contentsDir().resolve("content.txt"), firstFileContent);
+        Files.writeString(paths.versionRoot().resolve("checksum.sha256"), secondFileContent);
+    }
+}

--- a/docs/brain/node-command-dispatcher.md
+++ b/docs/brain/node-command-dispatcher.md
@@ -64,6 +64,20 @@ Body: `NodeInstanceCommandRequest`
 
 Body: `NodeInstanceCommandRequest`
 
+### Purge cache
+
+`POST /api/cache/purge`
+
+Body: optional `TemplateCachePurgeRequest`
+
+```json
+{
+  "templateId": "starter"
+}
+```
+
+When the body is omitted or `templateId` is null, the node purges the entire template cache.
+
 ## Configuration
 
 The Brain uses the following configuration properties:

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -45,6 +45,7 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.s3.region` (`NODE_AGENT_S3_REGION`)
 - When registration is enabled, the node agent reads the token from `node-agent.auth.token-path`
   and sends it to the Brain using `node-agent.auth.header-name`.
+- `node-agent.base-url` is used by the Brain to issue commands to the node (including cache purge).
 - When `node-agent.heartbeat-interval-seconds` is `0`, the node agent uses the heartbeat interval
   provided by the Brain during registration.
 - `node-agent.cache-dir` is the root for template cache storage. The node agent creates a

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -9,6 +9,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Expanded the startup log to include the effective configuration (sans secrets).
 - Added Brain registration on startup and in-memory caching of the assigned node id.
 - Added a heartbeat scheduler that reports node status and usage to the Brain.
+- Added a cache purge endpoint so the Brain can instruct nodes to clear cached templates.
 
 ## How to use / impact
 - Build and run with `./gradlew :node-agent:bootRun` from `backend/`.


### PR DESCRIPTION
## Description
- Implemented `TemplateCacheController` with `/api/cache/purge` endpoint to allow purging of all or specific cached templates.
- Added `TemplateCacheManager` for managing purge operations, including recursive deletion with safeguards.
- Introduced DTOs (`TemplateCachePurgeRequest`, `TemplateCachePurgeResponse`) for purge API request and response handling.
- Enhanced documentation to detail new cache purge API usage.
- Updated tests to cover all purge scenarios, including edge cases.

## Linked Issues
Closes #54

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
