### PR TITLE
feat(#56): add instance workspace support for node agent

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceException.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceException.java
@@ -1,0 +1,12 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+public class InstanceWorkspaceException extends RuntimeException {
+
+    public InstanceWorkspaceException(String message) {
+        super(message);
+    }
+
+    public InstanceWorkspaceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceLayout.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceLayout.java
@@ -1,0 +1,82 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceWorkspaceLayout {
+
+    public static final String INSTANCES_DIR_NAME = "instances";
+    public static final String MERGED_DIR_NAME = "merged";
+    public static final String LOGS_DIR_NAME = "logs";
+    public static final String TEMP_DIR_NAME = "temp";
+
+    private final Path workspaceRoot;
+    private final Path instancesRoot;
+
+    public InstanceWorkspaceLayout(NodeConfig config) {
+        if (config == null || config.getWorkspaceDir() == null || config.getWorkspaceDir().isBlank()) {
+            throw new InstanceWorkspaceException("node-agent.workspace-dir is required to build instance workspace layout");
+        }
+        String workspaceDir = config.getWorkspaceDir().trim();
+        try {
+            this.workspaceRoot = Paths.get(workspaceDir).toAbsolutePath().normalize();
+        } catch (InvalidPathException ex) {
+            throw new InstanceWorkspaceException("Invalid node-agent.workspace-dir: " + workspaceDir, ex);
+        }
+        this.instancesRoot = workspaceRoot.resolve(INSTANCES_DIR_NAME);
+    }
+
+    public Path getWorkspaceRoot() {
+        return workspaceRoot;
+    }
+
+    public Path getInstancesRoot() {
+        return instancesRoot;
+    }
+
+    public Path resolveInstanceRoot(String instanceId) {
+        String normalizedInstanceId = requireSegment("instanceId", instanceId);
+        return instancesRoot.resolve(normalizedInstanceId);
+    }
+
+    public InstanceWorkspacePaths resolveWorkspace(String instanceId) {
+        String normalizedInstanceId = requireSegment("instanceId", instanceId);
+        Path instanceRoot = instancesRoot.resolve(normalizedInstanceId);
+        Path mergedDir = instanceRoot.resolve(MERGED_DIR_NAME);
+        Path logsDir = instanceRoot.resolve(LOGS_DIR_NAME);
+        Path tempDir = instanceRoot.resolve(TEMP_DIR_NAME);
+        return new InstanceWorkspacePaths(
+                normalizedInstanceId,
+                instanceRoot,
+                mergedDir,
+                logsDir,
+                tempDir
+        );
+    }
+
+    private String requireSegment(String label, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        String trimmed = value.trim();
+        Path segment;
+        try {
+            segment = Paths.get(trimmed);
+        } catch (InvalidPathException ex) {
+            throw new IllegalArgumentException(label + " contains invalid path characters", ex);
+        }
+        if (segment.isAbsolute() || segment.getNameCount() != 1) {
+            throw new IllegalArgumentException(label + " must be a single path segment");
+        }
+        String name = segment.getFileName().toString();
+        if (".".equals(name) || "..".equals(name)) {
+            throw new IllegalArgumentException(label + " must not be '.' or '..'");
+        }
+        return name;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManager.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManager.java
@@ -1,0 +1,37 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceWorkspaceManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstanceWorkspaceManager.class);
+
+    private final InstanceWorkspaceLayout layout;
+
+    public InstanceWorkspaceManager(InstanceWorkspaceLayout layout) {
+        this.layout = layout;
+    }
+
+    public InstanceWorkspacePaths prepareWorkspace(String instanceId) {
+        InstanceWorkspacePaths paths = layout.resolveWorkspace(instanceId);
+        try {
+            Files.createDirectories(paths.instanceRoot());
+            Files.createDirectories(paths.mergedDir());
+            Files.createDirectories(paths.logsDir());
+            Files.createDirectories(paths.tempDir());
+        } catch (IOException ex) {
+            throw new InstanceWorkspaceException(
+                    "Failed to create workspace for instance " + instanceId + " at " + paths.instanceRoot(),
+                    ex
+            );
+        }
+        logger.debug("Workspace ready for instance {} at {}", paths.instanceId(), paths.instanceRoot());
+        return paths;
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspacePaths.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspacePaths.java
@@ -1,0 +1,12 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+import java.nio.file.Path;
+
+public record InstanceWorkspacePaths(
+        String instanceId,
+        Path instanceRoot,
+        Path mergedDir,
+        Path logsDir,
+        Path tempDir
+) {
+}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceLayoutTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceLayoutTest.java
@@ -1,0 +1,45 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InstanceWorkspaceLayoutTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolvesWorkspacePaths() {
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.resolve("workspace-root").toString());
+
+        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+        InstanceWorkspacePaths paths = layout.resolveWorkspace("instance-1");
+
+        Path expectedInstanceRoot = layout.getInstancesRoot().resolve("instance-1");
+
+        assertThat(paths.instanceId()).isEqualTo("instance-1");
+        assertThat(paths.instanceRoot()).isEqualTo(expectedInstanceRoot);
+        assertThat(paths.mergedDir()).isEqualTo(expectedInstanceRoot.resolve("merged"));
+        assertThat(paths.logsDir()).isEqualTo(expectedInstanceRoot.resolve("logs"));
+        assertThat(paths.tempDir()).isEqualTo(expectedInstanceRoot.resolve("temp"));
+    }
+
+    @Test
+    void rejectsInvalidInstanceId() {
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.resolve("workspace-root").toString());
+
+        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+
+        assertThatThrownBy(() -> layout.resolveWorkspace("../escape"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("instanceId");
+    }
+}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManagerTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManagerTest.java
@@ -1,0 +1,32 @@
+package net.spookly.kodama.nodeagent.instance.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InstanceWorkspaceManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void prepareWorkspaceCreatesDirectories() {
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.resolve("workspace-root").toString());
+
+        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+        InstanceWorkspaceManager manager = new InstanceWorkspaceManager(layout);
+
+        InstanceWorkspacePaths paths = manager.prepareWorkspace("instance-42");
+
+        assertThat(Files.isDirectory(paths.instanceRoot())).isTrue();
+        assertThat(Files.isDirectory(paths.mergedDir())).isTrue();
+        assertThat(Files.isDirectory(paths.logsDir())).isTrue();
+        assertThat(Files.isDirectory(paths.tempDir())).isTrue();
+    }
+}

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -51,6 +51,9 @@ Describe the configuration inputs for the node agent and how they map to environ
   provided by the Brain during registration.
 - `node-agent.cache-dir` is the root for template cache storage. The node agent creates a
   `templates/` subdirectory on startup. See `docs/node/operations/template-cache.md` for the layout.
+- `node-agent.workspace-dir` is the root for instance workspaces. The node agent creates
+  `instances/<instanceId>/{merged,logs,temp}` on demand when preparing a workspace.
+- See `docs/node/operations/instance-workspaces.md` for the full layout details.
 - Dev-mode defaults to `node-agent.dev-mode` and can be toggled at runtime via `POST /api/node/dev-mode`
   with body `{ "devMode": true|false }`. The runtime value is in-memory only; restarting the node agent
   resets it to the configured default.
@@ -75,3 +78,4 @@ Describe the configuration inputs for the node agent and how they map to environ
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/devmode/controller/DevModeController.java`
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/devmode/service/DevModeService.java`
 - `backend/node-agent/src/main/resources/application.yml`
+- `docs/node/operations/instance-workspaces.md`

--- a/docs/node/operations/instance-workspaces.md
+++ b/docs/node/operations/instance-workspaces.md
@@ -1,0 +1,27 @@
+# Instance Workspaces (Node Agent)
+
+## Purpose
+Describe how the node agent maps instance IDs to local workspace directories and prepares them for template/config merges.
+
+## What changed
+- Defined a deterministic on-disk layout for instance workspaces under `node-agent.workspace-dir`.
+- Added a helper that resolves and creates workspace folders for a given instance id.
+
+## How to use / impact
+- Workspace root: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances`.
+- Layout per instance:
+  - `<instanceId>/merged` for merged template/config output.
+  - `<instanceId>/logs` for instance logs.
+  - `<instanceId>/temp` for transient runtime files.
+- The node agent creates these directories when `prepareWorkspace(instanceId)` is called.
+- `instanceId` must be a single path segment (no slashes or `..`).
+
+## Edge cases / risks
+- If `node-agent.workspace-dir` is blank or invalid, workspace resolution fails with a clear error.
+- A malformed `instanceId` is rejected to prevent directory traversal.
+- Directory creation failures surface as `InstanceWorkspaceException` with the target path.
+
+## Links
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceLayout.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManager.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java`

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -11,6 +11,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Added a heartbeat scheduler that reports node status and usage to the Brain.
 - Added a cache purge endpoint so the Brain can instruct nodes to clear cached templates.
 - Added a dev-mode toggle endpoint so the Brain can force cache bypass on template fetches.
+- Added per-instance workspace layout helpers that create merged/config, logs, and temp folders on demand.
 
 ## How to use / impact
 - Build and run with `./gradlew :node-agent:bootRun` from `backend/`.
@@ -45,9 +46,10 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - If required configuration is missing, the node agent will exit on startup with a clear error.
 - If Brain registration fails, the node agent will exit on startup and log the error.
 - Heartbeat failures are logged with retries, but do not crash the node agent process.
-- The workspace directory is not created automatically yet.
+- Instance workspaces are created when requested; invalid workspace configuration will fail at request time.
 
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentApplication.java`
 - `backend/node-agent/src/main/resources/application.yml`
 - `docs/node/operations/configuration.md`
+- `docs/node/operations/instance-workspaces.md`


### PR DESCRIPTION
## Description
- Implemented deterministic instance workspace layout under `node-agent.workspace-dir`.
- Introduced `InstanceWorkspaceManager` and `InstanceWorkspaceLayout` for creating and managing workspaces.
- Added protections against invalid workspace configurations and malformed instance IDs to prevent directory traversal.
- Updated documentation to include workspace configuration, layout, and usage details.
- Enhanced test coverage for workspace resolution and directory creation logic.

## Linked Issues
Closes #56

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
