### PR TITLE
feat(#60): add health endpoint and lifecycle command handlers

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/health/controller/HealthController.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/health/controller/HealthController.java
@@ -1,0 +1,43 @@
+package net.spookly.kodama.nodeagent.health.controller;
+
+import java.util.UUID;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.health.dto.NodeHealthResponse;
+import net.spookly.kodama.nodeagent.registration.NodeRegistrationState;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    private final NodeConfig config;
+    private final NodeRegistrationState registrationState;
+
+    public HealthController(NodeConfig config, NodeRegistrationState registrationState) {
+        this.config = config;
+        this.registrationState = registrationState;
+    }
+
+    @GetMapping("/health")
+    public NodeHealthResponse health() {
+        return new NodeHealthResponse(
+                "ok",
+                resolveNodeId(),
+                config.getNodeName(),
+                config.getNodeVersion()
+        );
+    }
+
+    private String resolveNodeId() {
+        UUID registered = registrationState.getNodeId();
+        if (registered != null) {
+            return registered.toString();
+        }
+        String configured = config.getNodeId();
+        if (configured == null || configured.isBlank()) {
+            return null;
+        }
+        return configured.trim();
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/health/dto/NodeHealthResponse.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/health/dto/NodeHealthResponse.java
@@ -1,0 +1,9 @@
+package net.spookly.kodama.nodeagent.health.dto;
+
+public record NodeHealthResponse(
+        String status,
+        String nodeId,
+        String nodeName,
+        String nodeVersion
+) {
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackService.java
@@ -33,6 +33,18 @@ public class InstanceCallbackService {
         sendCallback(instanceId, "prepared");
     }
 
+    public void sendRunning(UUID instanceId) {
+        sendCallback(instanceId, "running");
+    }
+
+    public void sendStopped(UUID instanceId) {
+        sendCallback(instanceId, "stopped");
+    }
+
+    public void sendDestroyed(UUID instanceId) {
+        sendCallback(instanceId, "destroyed");
+    }
+
     public void sendFailed(UUID instanceId) {
         sendCallback(instanceId, "failed");
     }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java
@@ -2,8 +2,10 @@ package net.spookly.kodama.nodeagent.instance.controller;
 
 import java.util.UUID;
 
+import net.spookly.kodama.nodeagent.instance.dto.NodeInstanceCommandRequest;
 import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceRequest;
 import net.spookly.kodama.nodeagent.instance.service.InstancePrepareService;
+import net.spookly.kodama.nodeagent.instance.service.InstanceLifecycleService;
 import net.spookly.kodama.nodeagent.instance.service.InstancePrepareValidationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,9 +21,14 @@ import org.springframework.web.server.ResponseStatusException;
 public class InstanceCommandController {
 
     private final InstancePrepareService prepareService;
+    private final InstanceLifecycleService lifecycleService;
 
-    public InstanceCommandController(InstancePrepareService prepareService) {
+    public InstanceCommandController(
+            InstancePrepareService prepareService,
+            InstanceLifecycleService lifecycleService
+    ) {
         this.prepareService = prepareService;
+        this.lifecycleService = lifecycleService;
     }
 
     @PostMapping("/{instanceId}/prepare")
@@ -44,5 +51,63 @@ public class InstanceCommandController {
         } catch (InstancePrepareValidationException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }
+    }
+
+    @PostMapping("/{instanceId}/start")
+    @ResponseStatus(HttpStatus.OK)
+    public void start(
+            @PathVariable UUID instanceId,
+            @RequestBody(required = false) NodeInstanceCommandRequest request
+    ) {
+        NodeInstanceCommandRequest validated = requireCommand(instanceId, request);
+        try {
+            lifecycleService.start(validated);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    @PostMapping("/{instanceId}/stop")
+    @ResponseStatus(HttpStatus.OK)
+    public void stop(
+            @PathVariable UUID instanceId,
+            @RequestBody(required = false) NodeInstanceCommandRequest request
+    ) {
+        NodeInstanceCommandRequest validated = requireCommand(instanceId, request);
+        try {
+            lifecycleService.stop(validated);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    @PostMapping("/{instanceId}/destroy")
+    @ResponseStatus(HttpStatus.OK)
+    public void destroy(
+            @PathVariable UUID instanceId,
+            @RequestBody(required = false) NodeInstanceCommandRequest request
+    ) {
+        NodeInstanceCommandRequest validated = requireCommand(instanceId, request);
+        try {
+            lifecycleService.destroy(validated);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    private NodeInstanceCommandRequest requireCommand(
+            UUID instanceId,
+            NodeInstanceCommandRequest request
+    ) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request body is required");
+        }
+        if (request.instanceId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instanceId is required");
+        }
+        if (!instanceId.equals(request.instanceId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instanceId does not match path");
+        }
+        return request;
     }
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodeInstanceCommandRequest.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodeInstanceCommandRequest.java
@@ -1,0 +1,9 @@
+package net.spookly.kodama.nodeagent.instance.dto;
+
+import java.util.UUID;
+
+public record NodeInstanceCommandRequest(
+        UUID instanceId,
+        String name
+) {
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
@@ -1,0 +1,76 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import net.spookly.kodama.nodeagent.instance.callback.InstanceCallbackService;
+import net.spookly.kodama.nodeagent.instance.dto.NodeInstanceCommandRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceLifecycleService {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstanceLifecycleService.class);
+
+    private final InstanceCallbackService callbackService;
+
+    public InstanceLifecycleService(InstanceCallbackService callbackService) {
+        this.callbackService = Objects.requireNonNull(callbackService, "callbackService");
+    }
+
+    public void start(NodeInstanceCommandRequest request) {
+        UUID instanceId = requireInstanceId(request);
+        logger.info("Start command received. instanceId={} name={}", instanceId, valueOrDash(request.name()));
+        try {
+            callbackService.sendRunning(instanceId);
+            logger.info("Start command acknowledged. instanceId={}", instanceId);
+        } catch (RuntimeException ex) {
+            logger.warn("Start command callback failed. instanceId={}", instanceId, ex);
+            throw ex;
+        }
+    }
+
+    public void stop(NodeInstanceCommandRequest request) {
+        UUID instanceId = requireInstanceId(request);
+        logger.info("Stop command received. instanceId={} name={}", instanceId, valueOrDash(request.name()));
+        try {
+            callbackService.sendStopped(instanceId);
+            logger.info("Stop command acknowledged. instanceId={}", instanceId);
+        } catch (RuntimeException ex) {
+            logger.warn("Stop command callback failed. instanceId={}", instanceId, ex);
+            throw ex;
+        }
+    }
+
+    public void destroy(NodeInstanceCommandRequest request) {
+        UUID instanceId = requireInstanceId(request);
+        logger.info("Destroy command received. instanceId={} name={}", instanceId, valueOrDash(request.name()));
+        try {
+            callbackService.sendDestroyed(instanceId);
+            logger.info("Destroy command acknowledged. instanceId={}", instanceId);
+        } catch (RuntimeException ex) {
+            logger.warn("Destroy command callback failed. instanceId={}", instanceId, ex);
+            throw ex;
+        }
+    }
+
+    private UUID requireInstanceId(NodeInstanceCommandRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("instance command request is required");
+        }
+        UUID instanceId = request.instanceId();
+        if (instanceId == null) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        return instanceId;
+    }
+
+    private String valueOrDash(String value) {
+        if (value == null || value.isBlank()) {
+            return "-";
+        }
+        return value.trim();
+    }
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   application:
     name: kodama-node-agent
 
+server:
+  port: ${NODE_AGENT_HTTP_PORT:8080}
+  address: ${NODE_AGENT_HTTP_BIND_ADDRESS:0.0.0.0}
+
 node-agent:
   node-id: ${NODE_AGENT_ID:}
   node-name: ${NODE_AGENT_NAME:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
@@ -1,0 +1,53 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+
+import net.spookly.kodama.nodeagent.instance.callback.InstanceCallbackService;
+import net.spookly.kodama.nodeagent.instance.dto.NodeInstanceCommandRequest;
+import org.junit.jupiter.api.Test;
+
+class InstanceLifecycleServiceTest {
+
+    private final InstanceCallbackService callbackService = mock(InstanceCallbackService.class);
+    private final InstanceLifecycleService service = new InstanceLifecycleService(callbackService);
+
+    @Test
+    void startTriggersRunningCallback() {
+        UUID instanceId = UUID.randomUUID();
+
+        service.start(new NodeInstanceCommandRequest(instanceId, "demo"));
+
+        verify(callbackService).sendRunning(instanceId);
+    }
+
+    @Test
+    void stopTriggersStoppedCallback() {
+        UUID instanceId = UUID.randomUUID();
+
+        service.stop(new NodeInstanceCommandRequest(instanceId, "demo"));
+
+        verify(callbackService).sendStopped(instanceId);
+    }
+
+    @Test
+    void destroyTriggersDestroyedCallback() {
+        UUID instanceId = UUID.randomUUID();
+
+        service.destroy(new NodeInstanceCommandRequest(instanceId, "demo"));
+
+        verify(callbackService).sendDestroyed(instanceId);
+    }
+
+    @Test
+    void startRejectsMissingInstanceId() {
+        NodeInstanceCommandRequest request = new NodeInstanceCommandRequest(null, "demo");
+
+        assertThatThrownBy(() -> service.start(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("instanceId is required");
+    }
+}

--- a/contracts/nodeapi.yml
+++ b/contracts/nodeapi.yml
@@ -1,0 +1,125 @@
+title: Kodama Brain ↔ Node Agent API
+version: "0.1.0"
+description: Internal HTTP contract between the Brain and node agents. Not part of the public OpenAPI surface.
+
+endpoints:
+  health:
+    method: GET
+    path: /health
+    summary: Node agent health
+    response:
+      status: ok
+      nodeId: uuid|null
+      nodeName: string|null
+      nodeVersion: string|null
+
+  devMode:
+    get:
+      method: GET
+      path: /api/node/dev-mode
+      summary: Get dev-mode status
+      response:
+        devMode: boolean
+        previousDevMode: boolean
+        changed: boolean
+    post:
+      method: POST
+      path: /api/node/dev-mode
+      summary: Update dev-mode
+      request:
+        devMode: boolean
+      response:
+        devMode: boolean
+        previousDevMode: boolean
+        changed: boolean
+
+  templateCachePurge:
+    method: POST
+    path: /api/cache/purge
+    summary: Purge template cache
+    request:
+      templateId: string|optional
+    response:
+      scope: all|template
+      templateId: string|null
+      deletedFiles: int64
+      deletedDirectories: int64
+      deletedBytes: int64
+
+  instancePrepare:
+    method: POST
+    path: /api/instances/{instanceId}/prepare
+    summary: Prepare instance workspace
+    request:
+      instanceId: uuid
+      name: string|null
+      displayName: string|null
+      portsJson: string|null
+      variables: map<string,string>|null
+      variablesJson: string|null
+      layers:
+        - templateVersionId: uuid
+          templateId: uuid
+          version: string
+          checksum: string
+          s3Key: string
+          metadataJson: string|null
+          orderIndex: int32
+    responses:
+      "200": OK
+      "400": Bad Request
+
+  instanceStart:
+    method: POST
+    path: /api/instances/{instanceId}/start
+    summary: Start instance
+    request:
+      instanceId: uuid
+      name: string|null
+    responses:
+      "200": OK
+      "400": Bad Request
+
+  instanceStop:
+    method: POST
+    path: /api/instances/{instanceId}/stop
+    summary: Stop instance
+    request:
+      instanceId: uuid
+      name: string|null
+    responses:
+      "200": OK
+      "400": Bad Request
+
+  instanceDestroy:
+    method: POST
+    path: /api/instances/{instanceId}/destroy
+    summary: Destroy instance
+    request:
+      instanceId: uuid
+      name: string|null
+    responses:
+      "200": OK
+      "400": Bad Request
+
+callbacks:
+  prepared:
+    method: POST
+    path: /api/nodes/{nodeId}/instances/{instanceId}/prepared
+  running:
+    method: POST
+    path: /api/nodes/{nodeId}/instances/{instanceId}/running
+  stopped:
+    method: POST
+    path: /api/nodes/{nodeId}/instances/{instanceId}/stopped
+  destroyed:
+    method: POST
+    path: /api/nodes/{nodeId}/instances/{instanceId}/destroyed
+  failed:
+    method: POST
+    path: /api/nodes/{nodeId}/instances/{instanceId}/failed
+
+notes:
+  - Dev-mode updates are in-memory only; restart resets to configured defaults.
+  - Start/stop/destroy are acknowledgements only; runtime control is not implemented yet.
+  - Validation errors return 400 and stop command processing.

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -32,6 +32,8 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.base-url` (`NODE_AGENT_BASE_URL`)
   - `node-agent.registration-enabled` (`NODE_AGENT_REGISTRATION_ENABLED`, default `true`)
   - `node-agent.heartbeat-interval-seconds` (`NODE_AGENT_HEARTBEAT_INTERVAL_SECONDS`, default `0`)
+  - `server.port` (`NODE_AGENT_HTTP_PORT`, default `8080`)
+  - `server.address` (`NODE_AGENT_HTTP_BIND_ADDRESS`, default `0.0.0.0`)
   - `node-agent.workspace-dir` (`NODE_AGENT_WORKSPACE_DIR`, default `./data`)
   - `node-agent.docker-host` (`NODE_AGENT_DOCKER_HOST`)
   - `node-agent.template-cache-check.enabled` (`NODE_AGENT_TEMPLATE_CACHE_CHECK_ENABLED`, default `false`)
@@ -48,6 +50,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - When registration is enabled, the node agent reads the token from `node-agent.auth.token-path`
   and sends it to the Brain using `node-agent.auth.header-name`.
 - `node-agent.base-url` is used by the Brain to issue commands to the node (including cache purge).
+- `server.port` and `server.address` control the embedded HTTP listener used by the Brain to issue commands.
 - When `node-agent.heartbeat-interval-seconds` is `0`, the node agent uses the heartbeat interval
   provided by the Brain during registration.
 - `node-agent.cache-dir` is the root for template cache storage. The node agent creates a

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -6,6 +6,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 ## What changed
 - Added an instance prepare command handler that assembles cached template layers into a workspace.
 - Added variable substitution and Brain callbacks as part of the prepare flow.
+- Added start/stop/destroy command handlers that send lifecycle callbacks to the Brain.
 
 ## How to use / impact
 - `POST /api/instances/{instanceId}/prepare` with `NodePrepareInstanceRequest`.
@@ -14,6 +15,14 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
   - merges layers into the instance `merged` workspace,
   - applies variable substitution,
   - calls back to the Brain with `/api/nodes/{nodeId}/instances/{instanceId}/prepared` (includes the node auth header when configured).
+- `POST /api/instances/{instanceId}/start` with `NodeInstanceCommandRequest`.
+- `POST /api/instances/{instanceId}/stop` with `NodeInstanceCommandRequest`.
+- `POST /api/instances/{instanceId}/destroy` with `NodeInstanceCommandRequest`.
+- `NodeInstanceCommandRequest` requires `instanceId` and accepts an optional `name` for logging.
+- Start/stop/destroy currently acknowledge commands by calling back to the Brain:
+  - `/api/nodes/{nodeId}/instances/{instanceId}/running`
+  - `/api/nodes/{nodeId}/instances/{instanceId}/stopped`
+  - `/api/nodes/{nodeId}/instances/{instanceId}/destroyed`
 - `variables` and `variablesJson` are mutually exclusive. When `variablesJson` is provided, the node agent parses it as a JSON map.
 - Template cache lookups use `templateId` from the prepare payload as the cache key.
 
@@ -21,9 +30,12 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Invalid payloads (missing instanceId, empty layers, invalid JSON) return HTTP 400 and trigger a `/failed` callback when possible.
 - Cache download/merge failures result in HTTP 500 and a `/failed` callback attempt.
 - Missing node auth token or invalid Brain base URL prevents callbacks and fails the prepare request.
+- Start/stop/destroy commands are acknowledged via callbacks only; instance runtime control is not implemented yet.
 
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java`
+- `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java`
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstancePrepareService.java`
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceVariablesResolver.java`
+- `contracts/nodeapi.yml`
 - `docs/brain/node-command-dispatcher.md`

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -15,6 +15,8 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Added a template layer merge service that applies cached templates into the merged workspace directory.
 - Added variable substitution over merged workspace text files using Brain-provided values.
 - Added a prepare command handler that assembles templates, applies variable substitution, and calls back to the Brain.
+- Added a health endpoint for basic node-agent diagnostics.
+- Added start/stop/destroy command handlers that send callbacks to the Brain.
 
 ## How to use / impact
 - Build and run with `./gradlew :node-agent:bootRun` from `backend/`.
@@ -33,6 +35,8 @@ The Node Agent is a lightweight Java service that runs on each node and executes
     - `NODE_AGENT_BASE_URL`
     - `NODE_AGENT_REGISTRATION_ENABLED`
     - `NODE_AGENT_HEARTBEAT_INTERVAL_SECONDS` (override Brain-provided interval)
+    - `NODE_AGENT_HTTP_PORT` (defaults to `8080`)
+    - `NODE_AGENT_HTTP_BIND_ADDRESS` (defaults to `0.0.0.0`)
     - `NODE_AGENT_WORKSPACE_DIR`
     - `NODE_AGENT_DOCKER_HOST`
     - `NODE_AGENT_VARIABLE_SUBSTITUTION_MAX_FILE_BYTES`
@@ -45,6 +49,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
     - `NODE_AGENT_S3_ACCESS_KEY`
     - `NODE_AGENT_S3_SECRET_KEY`
 - See `docs/node/operations/configuration.md` for the full mapping.
+- Health check is available at `GET /health` on the configured node-agent HTTP port.
 
 ## Edge cases / risks
 - If required configuration is missing, the node agent will exit on startup with a clear error.
@@ -55,6 +60,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/NodeAgentApplication.java`
 - `backend/node-agent/src/main/resources/application.yml`
+- `contracts/nodeapi.yml`
 - `docs/node/operations/configuration.md`
 - `docs/node/operations/instance-workspaces.md`
 - `docs/node/operations/template-merge.md`


### PR DESCRIPTION
## Description
- Introduced `HealthController` with a `/health` endpoint for basic diagnostics.
- Implemented lifecycle command handlers (`start`, `stop`, `destroy`) in `InstanceLifecycleService` with Brain callback integration.
- Updated `InstanceCommandController` to support new lifecycle commands.
- Enhanced documentation and configuration for lifecycle handling and health checks.
- Added tests for lifecycle callbacks and validation logic.

## Linked Issues
Closes #60

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
