### PR TITLE
feat(#63): add instance stop service with container lifecycle management

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
@@ -63,6 +63,14 @@ public class NodeConfig {
         } else if (variableSubstitution.getMaxFileBytes() < 0) {
             errors.add("node-agent.variable-substitution.max-file-bytes must be 0 or greater");
         }
+        if (instanceRuntime == null) {
+            errors.add("node-agent.instance-runtime is required");
+        } else {
+            Integer stopTimeoutSeconds = instanceRuntime.getStopTimeoutSeconds();
+            if (stopTimeoutSeconds != null && stopTimeoutSeconds < 0) {
+                errors.add("node-agent.instance-runtime.stop-timeout-seconds must be 0 or greater");
+            }
+        }
         if (docker == null) {
             errors.add("node-agent.docker is required");
         } else {
@@ -427,6 +435,7 @@ public class NodeConfig {
         private String image;
         private String workspaceMountPath = "/workspace";
         private String workingDir;
+        private Integer stopTimeoutSeconds;
 
         public String getImage() {
             return image;
@@ -450,6 +459,14 @@ public class NodeConfig {
 
         public void setWorkingDir(String workingDir) {
             this.workingDir = workingDir;
+        }
+
+        public Integer getStopTimeoutSeconds() {
+            return stopTimeoutSeconds;
+        }
+
+        public void setStopTimeoutSeconds(Integer stopTimeoutSeconds) {
+            this.stopTimeoutSeconds = stopTimeoutSeconds;
         }
     }
 

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/docker/service/DockerService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/docker/service/DockerService.java
@@ -113,6 +113,17 @@ public class DockerService {
         }
     }
 
+    public void killContainer(String containerId) {
+        String normalizedId = requireContainerId(containerId);
+        try {
+            dockerClient.killContainerCmd(normalizedId).exec();
+        } catch (NotFoundException ex) {
+            throw new DockerOperationException("Docker container not found: " + normalizedId, ex);
+        } catch (DockerException ex) {
+            throw new DockerOperationException("Docker kill container failed: " + normalizedId, ex);
+        }
+    }
+
     public void removeContainer(String containerId, boolean force, boolean removeVolumes) {
         String normalizedId = requireContainerId(containerId);
         try {
@@ -149,6 +160,33 @@ public class DockerService {
             );
         } catch (NotFoundException ex) {
             throw new DockerOperationException("Docker container not found: " + normalizedId, ex);
+        } catch (DockerException ex) {
+            throw new DockerOperationException("Docker inspect container failed: " + normalizedId, ex);
+        }
+    }
+
+    public DockerContainerStatus inspectContainerIfExists(String containerId) {
+        String normalizedId = requireContainerId(containerId);
+        try {
+            InspectContainerResponse response = dockerClient.inspectContainerCmd(normalizedId).exec();
+            InspectContainerResponse.ContainerState state = response.getState();
+            return new DockerContainerStatus(
+                    response.getId(),
+                    response.getName(),
+                    response.getConfig() == null ? null : response.getConfig().getImage(),
+                    state == null ? null : state.getStatus(),
+                    state == null ? null : state.getRunning(),
+                    state == null ? null : state.getPaused(),
+                    state == null ? null : state.getRestarting(),
+                    state == null ? null : state.getOOMKilled(),
+                    state == null ? null : state.getDead(),
+                    state == null ? null : state.getExitCode(),
+                    state == null ? null : state.getError(),
+                    state == null ? null : state.getStartedAt(),
+                    state == null ? null : state.getFinishedAt()
+            );
+        } catch (NotFoundException ex) {
+            return null;
         } catch (DockerException ex) {
             throw new DockerOperationException("Docker inspect container failed: " + normalizedId, ex);
         }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
@@ -15,6 +15,8 @@ public record InstanceRegistryEntry(
         Map<String, String> variables,
         List<NodePrepareInstanceLayer> layers,
         OffsetDateTime preparedAt,
-        String containerId
+        String containerId,
+        String containerStatus,
+        OffsetDateTime containerStatusUpdatedAt
 ) {
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
@@ -62,6 +62,8 @@ public class InstanceRegistryService {
                 safeVariables,
                 new ArrayList<>(safeLayers),
                 OffsetDateTime.now(),
+                null,
+                null,
                 null
         );
 
@@ -118,11 +120,55 @@ public class InstanceRegistryService {
                 entry.variables(),
                 entry.layers(),
                 entry.preparedAt(),
-                containerId.trim()
+                containerId.trim(),
+                "running",
+                OffsetDateTime.now()
         );
         Path registryFile = workspace.instanceRoot().resolve(REGISTRY_FILENAME);
         writeRegistry(registryFile, updated);
         logger.info("Instance registry updated with containerId. instanceId={} containerId={}", instanceId, containerId);
+    }
+
+    public void recordContainerStatus(
+            InstanceWorkspacePaths workspace,
+            UUID instanceId,
+            String containerStatus
+    ) {
+        if (workspace == null) {
+            throw new InstanceRegistryException("instance workspace is required");
+        }
+        requireInstanceId(instanceId);
+        if (containerStatus == null || containerStatus.isBlank()) {
+            throw new InstanceRegistryException("containerStatus is required");
+        }
+        requireMatchingInstanceId(instanceId, workspace.instanceId());
+        InstanceRegistryEntry entry = loadRegistry(workspace);
+        if (!instanceId.equals(entry.instanceId())) {
+            throw new InstanceRegistryException("instanceId does not match registry: " + instanceId + " vs " + entry.instanceId());
+        }
+        if (entry.containerId() == null || entry.containerId().isBlank()) {
+            throw new InstanceRegistryException("containerId is required");
+        }
+        InstanceRegistryEntry updated = new InstanceRegistryEntry(
+                entry.instanceId(),
+                entry.name(),
+                entry.displayName(),
+                entry.portsJson(),
+                entry.variables(),
+                entry.layers(),
+                entry.preparedAt(),
+                entry.containerId().trim(),
+                containerStatus.trim(),
+                OffsetDateTime.now()
+        );
+        Path registryFile = workspace.instanceRoot().resolve(REGISTRY_FILENAME);
+        writeRegistry(registryFile, updated);
+        logger.info(
+                "Instance registry updated with containerStatus. instanceId={} containerId={} status={}",
+                instanceId,
+                entry.containerId(),
+                containerStatus
+        );
     }
 
     private void writeRegistry(Path registryFile, InstanceRegistryEntry entry) {

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
@@ -16,13 +16,16 @@ public class InstanceLifecycleService {
 
     private final InstanceCallbackService callbackService;
     private final InstanceStartService startService;
+    private final InstanceStopService stopService;
 
     public InstanceLifecycleService(
-            InstanceCallbackService callbackService,
-            InstanceStartService startService
+           InstanceCallbackService callbackService,
+           InstanceStartService startService,
+           InstanceStopService stopService
     ) {
         this.callbackService = Objects.requireNonNull(callbackService, "callbackService");
         this.startService = Objects.requireNonNull(startService, "startService");
+        this.stopService = Objects.requireNonNull(stopService, "stopService");
     }
 
     public void start(NodeInstanceCommandRequest request) {
@@ -50,6 +53,17 @@ public class InstanceLifecycleService {
     public void stop(NodeInstanceCommandRequest request) {
         UUID instanceId = requireInstanceId(request);
         logger.info("Stop command received. instanceId={} name={}", instanceId, valueOrDash(request.name()));
+        try {
+            stopService.stopInstance(instanceId);
+        } catch (RuntimeException ex) {
+            try {
+                callbackService.sendFailed(instanceId);
+            } catch (RuntimeException callbackEx) {
+                logger.warn("Stop command failure callback failed. instanceId={}", instanceId, callbackEx);
+            }
+            logger.warn("Stop command failed. instanceId={}", instanceId, ex);
+            throw ex;
+        }
         try {
             callbackService.sendStopped(instanceId);
             logger.info("Stop command acknowledged. instanceId={}", instanceId);

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopException.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopException.java
@@ -1,0 +1,7 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class InstanceStopException extends RuntimeException {
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopService.java
@@ -1,0 +1,159 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import java.nio.file.Files;
+import java.util.UUID;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.NotModifiedException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.docker.dto.DockerContainerStatus;
+import net.spookly.kodama.nodeagent.docker.service.DockerOperationException;
+import net.spookly.kodama.nodeagent.docker.service.DockerService;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryEntry;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceLayout;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InstanceStopService {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstanceStopService.class);
+
+    @NonNull
+    private final DockerService dockerService;
+    @NonNull
+    private final InstanceRegistryService registryService;
+    @NonNull
+    private final InstanceWorkspaceLayout workspaceLayout;
+    @NonNull
+    private final NodeConfig config;
+
+    public void stopInstance(UUID instanceId) {
+        if (instanceId == null) {
+            throw new InstanceStopException("instanceId is required");
+        }
+        InstanceWorkspacePaths workspace = workspaceLayout.resolveWorkspace(instanceId.toString());
+        requireWorkspace(workspace);
+        InstanceRegistryEntry registry = registryService.loadRegistry(workspace);
+        if (!instanceId.equals(registry.instanceId())) {
+            throw new InstanceStopException("Instance registry does not match instanceId: " + instanceId);
+        }
+        String containerId = requireContainerId(registry.containerId());
+        DockerContainerStatus initialStatus = dockerService.inspectContainerIfExists(containerId);
+        if (initialStatus == null) {
+            logger.warn(
+                    "Instance container not found, marking stopped. instanceId={} containerId={}",
+                    instanceId,
+                    containerId
+            );
+            registryService.recordContainerStatus(workspace, instanceId, "stopped");
+            return;
+        }
+        if (Boolean.FALSE.equals(initialStatus.running())) {
+            logger.info(
+                    "Instance container already stopped. instanceId={} containerId={} status={}",
+                    instanceId,
+                    containerId,
+                    safeStatus(initialStatus)
+            );
+            registryService.recordContainerStatus(workspace, instanceId, "stopped");
+            return;
+        }
+        Integer stopTimeoutSeconds = resolveStopTimeoutSeconds();
+        try {
+            dockerService.stopContainer(containerId, stopTimeoutSeconds);
+        } catch (DockerOperationException ex) {
+            if (isStopRace(ex)) {
+                logger.warn(
+                        "Instance container already stopped during stop. instanceId={} containerId={}",
+                        instanceId,
+                        containerId
+                );
+                registryService.recordContainerStatus(workspace, instanceId, "stopped");
+                return;
+            }
+            throw ex;
+        }
+        DockerContainerStatus stoppedStatus = dockerService.inspectContainerIfExists(containerId);
+        if (stoppedStatus != null && Boolean.TRUE.equals(stoppedStatus.running())) {
+            logger.warn(
+                    "Instance container still running after stop, forcing kill. instanceId={} containerId={}",
+                    instanceId,
+                    containerId
+            );
+            try {
+                dockerService.killContainer(containerId);
+            } catch (DockerOperationException ex) {
+                if (isStopRace(ex)) {
+                    logger.warn(
+                            "Instance container already stopped during kill. instanceId={} containerId={}",
+                            instanceId,
+                            containerId
+                    );
+                    registryService.recordContainerStatus(workspace, instanceId, "stopped");
+                    return;
+                }
+                throw ex;
+            }
+            stoppedStatus = dockerService.inspectContainerIfExists(containerId);
+            if (stoppedStatus != null && Boolean.TRUE.equals(stoppedStatus.running())) {
+                throw new InstanceStopException("Container still running after force kill: " + containerId);
+            }
+        }
+        registryService.recordContainerStatus(workspace, instanceId, "stopped");
+        logger.info(
+                "Instance container stopped. instanceId={} containerId={} status={}",
+                instanceId,
+                containerId,
+                safeStatus(stoppedStatus)
+        );
+    }
+
+    private void requireWorkspace(InstanceWorkspacePaths workspace) {
+        if (workspace == null) {
+            throw new InstanceStopException("instance workspace is required");
+        }
+        if (!Files.isDirectory(workspace.instanceRoot())) {
+            throw new InstanceStopException("Instance workspace root is missing at " + workspace.instanceRoot());
+        }
+    }
+
+    private String requireContainerId(String containerId) {
+        if (containerId == null || containerId.isBlank()) {
+            throw new InstanceStopException("containerId is required to stop instance");
+        }
+        return containerId.trim();
+    }
+
+    private Integer resolveStopTimeoutSeconds() {
+        if (config.getInstanceRuntime() == null) {
+            return null;
+        }
+        return config.getInstanceRuntime().getStopTimeoutSeconds();
+    }
+
+    private boolean isStopRace(DockerOperationException ex) {
+        if (ex == null) {
+            return false;
+        }
+        Throwable cause = ex.getCause();
+        return cause instanceof NotFoundException || cause instanceof NotModifiedException;
+    }
+
+    private String safeStatus(DockerContainerStatus status) {
+        if (status == null) {
+            return "unknown";
+        }
+        String state = status.status();
+        if (state == null || state.isBlank()) {
+            return "unknown";
+        }
+        return state.trim();
+    }
+}

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -45,6 +45,7 @@ node-agent:
     image: ${NODE_AGENT_INSTANCE_RUNTIME_IMAGE:}
     workspace-mount-path: ${NODE_AGENT_INSTANCE_RUNTIME_WORKSPACE_MOUNT_PATH:/workspace}
     working-dir: ${NODE_AGENT_INSTANCE_RUNTIME_WORKING_DIR:}
+    stop-timeout-seconds: ${NODE_AGENT_INSTANCE_RUNTIME_STOP_TIMEOUT_SECONDS:}
   auth:
     header-name: ${NODE_AGENT_AUTH_HEADER_NAME:X-Node-Token}
     token-path: ${NODE_AGENT_AUTH_TOKEN_PATH:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/config/NodeConfigTest.java
@@ -120,6 +120,22 @@ class NodeConfigTest {
     }
 
     @Test
+    void validateRejectsNegativeStopTimeout() {
+        NodeConfig config = new NodeConfig();
+        config.setNodeName("Node 1");
+        config.setNodeVersion("1.0.0");
+        config.setRegion("local");
+        config.setCapacitySlots(4);
+        config.setBrainBaseUrl("http://brain:8080");
+        config.setCacheDir("./cache");
+        config.getInstanceRuntime().setStopTimeoutSeconds(-1);
+
+        assertThatThrownBy(config::validate)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("node-agent.instance-runtime.stop-timeout-seconds must be 0 or greater");
+    }
+
+    @Test
     void validateAcceptsDockerTlsVerifyWhenCertConfigMissing() {
         NodeConfig config = new NodeConfig();
         config.setNodeName("Node 1");

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
@@ -66,6 +66,8 @@ class InstanceRegistryServiceTest {
         assertThat(entry.layers().get(0).templateId()).isEqualTo(layer.templateId());
         assertThat(entry.preparedAt()).isNotNull();
         assertThat(entry.containerId()).isNull();
+        assertThat(entry.containerStatus()).isNull();
+        assertThat(entry.containerStatusUpdatedAt()).isNull();
     }
 
     @Test
@@ -129,6 +131,44 @@ class InstanceRegistryServiceTest {
         Path registryFile = workspace.instanceRoot().resolve("instance.json");
         InstanceRegistryEntry entry = objectMapper().readValue(registryFile.toFile(), InstanceRegistryEntry.class);
         assertThat(entry.containerId()).isEqualTo("container-123");
+        assertThat(entry.containerStatus()).isEqualTo("running");
+        assertThat(entry.containerStatusUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void recordContainerStatusUpdatesRegistry() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        NodePrepareInstanceLayer layer = new NodePrepareInstanceLayer(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "1.0.0",
+                "checksum",
+                "s3/key.tgz",
+                null,
+                0
+        );
+        List<NodePrepareInstanceLayer> layers = List.of(layer);
+        NodePrepareInstanceRequest request = new NodePrepareInstanceRequest(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                null,
+                layers
+        );
+        InstanceWorkspacePaths workspace = prepareWorkspace(instanceId.toString());
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+
+        registryService.recordPrepared(workspace, request, layers, Map.of());
+        registryService.recordContainerId(workspace, instanceId, "container-123");
+        registryService.recordContainerStatus(workspace, instanceId, "stopped");
+
+        Path registryFile = workspace.instanceRoot().resolve("instance.json");
+        InstanceRegistryEntry entry = objectMapper().readValue(registryFile.toFile(), InstanceRegistryEntry.class);
+        assertThat(entry.containerId()).isEqualTo("container-123");
+        assertThat(entry.containerStatus()).isEqualTo("stopped");
+        assertThat(entry.containerStatusUpdatedAt()).isNotNull();
     }
 
     private InstanceWorkspacePaths prepareWorkspace(String instanceId) {

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
@@ -17,7 +17,8 @@ class InstanceLifecycleServiceTest {
 
     private final InstanceCallbackService callbackService = mock(InstanceCallbackService.class);
     private final InstanceStartService startService = mock(InstanceStartService.class);
-    private final InstanceLifecycleService service = new InstanceLifecycleService(callbackService, startService);
+    private final InstanceStopService stopService = mock(InstanceStopService.class);
+    private final InstanceLifecycleService service = new InstanceLifecycleService(callbackService, startService, stopService);
 
     @Test
     void startTriggersRunningCallback() {
@@ -35,6 +36,7 @@ class InstanceLifecycleServiceTest {
 
         service.stop(new NodeInstanceCommandRequest(instanceId, "demo"));
 
+        verify(stopService).stopInstance(instanceId);
         verify(callbackService).sendStopped(instanceId);
     }
 
@@ -64,6 +66,20 @@ class InstanceLifecycleServiceTest {
                 .startInstance(instanceId, "demo");
 
         assertThatThrownBy(() -> service.start(new NodeInstanceCommandRequest(instanceId, "demo")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("boom");
+
+        verify(callbackService).sendFailed(instanceId);
+    }
+
+    @Test
+    void stopFailureSendsFailedCallback() {
+        UUID instanceId = UUID.randomUUID();
+        doThrow(new RuntimeException("boom"))
+                .when(stopService)
+                .stopInstance(instanceId);
+
+        assertThatThrownBy(() -> service.stop(new NodeInstanceCommandRequest(instanceId, "demo")))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("boom");
 

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePortBindingsResolverTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePortBindingsResolverTest.java
@@ -26,6 +26,8 @@ class InstancePortBindingsResolverTest {
                 Map.of("PORT_GAME", "30000"),
                 List.of(),
                 OffsetDateTime.now(),
+                null,
+                null,
                 null
         );
 
@@ -47,6 +49,8 @@ class InstancePortBindingsResolverTest {
                 Map.of("PORT", "25565"),
                 List.of(),
                 OffsetDateTime.now(),
+                null,
+                null,
                 null
         );
 
@@ -72,6 +76,8 @@ class InstancePortBindingsResolverTest {
                 variables,
                 List.of(),
                 OffsetDateTime.now(),
+                null,
+                null,
                 null
         );
 

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStartServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStartServiceTest.java
@@ -55,6 +55,8 @@ class InstanceStartServiceTest {
                 Map.of("ENV", "prod"),
                 List.of(),
                 OffsetDateTime.now(),
+                null,
+                null,
                 null
         );
 

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopServiceTest.java
@@ -1,0 +1,241 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.NotModifiedException;
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.docker.dto.DockerContainerStatus;
+import net.spookly.kodama.nodeagent.docker.service.DockerOperationException;
+import net.spookly.kodama.nodeagent.docker.service.DockerService;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryEntry;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceLayout;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InstanceStopServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void stopInstanceStopsContainerAndUpdatesRegistry() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        String containerId = "container-1";
+        InstanceWorkspacePaths workspace = createWorkspace(instanceId);
+        InstanceRegistryEntry registry = new InstanceRegistryEntry(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                List.of(),
+                OffsetDateTime.now(),
+                containerId,
+                "running",
+                OffsetDateTime.now()
+        );
+
+        DockerService dockerService = mock(DockerService.class);
+        InstanceRegistryService registryService = mock(InstanceRegistryService.class);
+        InstanceWorkspaceLayout workspaceLayout = mock(InstanceWorkspaceLayout.class);
+
+        when(workspaceLayout.resolveWorkspace(instanceId.toString())).thenReturn(workspace);
+        when(registryService.loadRegistry(workspace)).thenReturn(registry);
+        when(dockerService.inspectContainerIfExists(containerId))
+                .thenReturn(status(containerId, true, "running"), status(containerId, false, "exited"));
+
+        NodeConfig config = new NodeConfig();
+        config.getInstanceRuntime().setStopTimeoutSeconds(15);
+
+        InstanceStopService service = new InstanceStopService(
+                dockerService,
+                registryService,
+                workspaceLayout,
+                config
+        );
+
+        service.stopInstance(instanceId);
+
+        verify(dockerService).stopContainer(containerId, 15);
+        verify(dockerService, never()).killContainer(containerId);
+        verify(registryService).recordContainerStatus(workspace, instanceId, "stopped");
+    }
+
+    @Test
+    void stopInstanceKillsContainerWhenStillRunningAfterStop() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        String containerId = "container-2";
+        InstanceWorkspacePaths workspace = createWorkspace(instanceId);
+        InstanceRegistryEntry registry = new InstanceRegistryEntry(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                List.of(),
+                OffsetDateTime.now(),
+                containerId,
+                "running",
+                OffsetDateTime.now()
+        );
+
+        DockerService dockerService = mock(DockerService.class);
+        InstanceRegistryService registryService = mock(InstanceRegistryService.class);
+        InstanceWorkspaceLayout workspaceLayout = mock(InstanceWorkspaceLayout.class);
+
+        when(workspaceLayout.resolveWorkspace(instanceId.toString())).thenReturn(workspace);
+        when(registryService.loadRegistry(workspace)).thenReturn(registry);
+        when(dockerService.inspectContainerIfExists(containerId))
+                .thenReturn(
+                        status(containerId, true, "running"),
+                        status(containerId, true, "running"),
+                        status(containerId, false, "exited")
+                );
+
+        NodeConfig config = new NodeConfig();
+
+        InstanceStopService service = new InstanceStopService(
+                dockerService,
+                registryService,
+                workspaceLayout,
+                config
+        );
+
+        service.stopInstance(instanceId);
+
+        verify(dockerService).stopContainer(containerId, null);
+        verify(dockerService).killContainer(containerId);
+        verify(registryService).recordContainerStatus(workspace, instanceId, "stopped");
+    }
+
+    @Test
+    void stopInstanceTreatsNotFoundDuringStopAsStopped() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        String containerId = "container-3";
+        InstanceWorkspacePaths workspace = createWorkspace(instanceId);
+        InstanceRegistryEntry registry = new InstanceRegistryEntry(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                List.of(),
+                OffsetDateTime.now(),
+                containerId,
+                "running",
+                OffsetDateTime.now()
+        );
+
+        DockerService dockerService = mock(DockerService.class);
+        InstanceRegistryService registryService = mock(InstanceRegistryService.class);
+        InstanceWorkspaceLayout workspaceLayout = mock(InstanceWorkspaceLayout.class);
+
+        when(workspaceLayout.resolveWorkspace(instanceId.toString())).thenReturn(workspace);
+        when(registryService.loadRegistry(workspace)).thenReturn(registry);
+        when(dockerService.inspectContainerIfExists(containerId))
+                .thenReturn(status(containerId, true, "running"));
+        doThrow(new DockerOperationException("Docker container not found: " + containerId, new NotFoundException("missing")))
+                .when(dockerService)
+                .stopContainer(containerId, null);
+
+        InstanceStopService service = new InstanceStopService(
+                dockerService,
+                registryService,
+                workspaceLayout,
+                new NodeConfig()
+        );
+
+        assertThatNoException().isThrownBy(() -> service.stopInstance(instanceId));
+
+        verify(dockerService, never()).killContainer(containerId);
+        verify(registryService).recordContainerStatus(workspace, instanceId, "stopped");
+    }
+
+    @Test
+    void stopInstanceTreatsNotRunningDuringStopAsStopped() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        String containerId = "container-4";
+        InstanceWorkspacePaths workspace = createWorkspace(instanceId);
+        InstanceRegistryEntry registry = new InstanceRegistryEntry(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                List.of(),
+                OffsetDateTime.now(),
+                containerId,
+                "running",
+                OffsetDateTime.now()
+        );
+
+        DockerService dockerService = mock(DockerService.class);
+        InstanceRegistryService registryService = mock(InstanceRegistryService.class);
+        InstanceWorkspaceLayout workspaceLayout = mock(InstanceWorkspaceLayout.class);
+
+        when(workspaceLayout.resolveWorkspace(instanceId.toString())).thenReturn(workspace);
+        when(registryService.loadRegistry(workspace)).thenReturn(registry);
+        when(dockerService.inspectContainerIfExists(containerId))
+                .thenReturn(status(containerId, true, "running"));
+        doThrow(new DockerOperationException("Docker container not running: " + containerId, new NotModifiedException("stopped")))
+                .when(dockerService)
+                .stopContainer(containerId, null);
+
+        InstanceStopService service = new InstanceStopService(
+                dockerService,
+                registryService,
+                workspaceLayout,
+                new NodeConfig()
+        );
+
+        assertThatNoException().isThrownBy(() -> service.stopInstance(instanceId));
+
+        verify(dockerService, never()).killContainer(containerId);
+        verify(registryService).recordContainerStatus(workspace, instanceId, "stopped");
+    }
+
+    private InstanceWorkspacePaths createWorkspace(UUID instanceId) throws Exception {
+        Path instanceRoot = tempDir.resolve("instances").resolve(instanceId.toString());
+        Files.createDirectories(instanceRoot);
+        return new InstanceWorkspacePaths(
+                instanceId.toString(),
+                instanceRoot,
+                instanceRoot.resolve("merged"),
+                instanceRoot.resolve("logs"),
+                instanceRoot.resolve("temp")
+        );
+    }
+
+    private DockerContainerStatus status(String containerId, Boolean running, String state) {
+        return new DockerContainerStatus(
+                containerId,
+                null,
+                null,
+                state,
+                running,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/contracts/nodeapi.yml
+++ b/contracts/nodeapi.yml
@@ -131,5 +131,6 @@ callbacks:
 notes:
   - Dev-mode updates are in-memory only; restart resets to configured defaults.
   - Start now creates and starts a Docker container for the prepared workspace and records the container id locally.
-  - Stop/destroy are acknowledgements only; runtime control is not implemented yet.
+  - Stop now resolves the container id from the local registry, stops the container, and updates the registry state to stopped.
+  - `node-agent.instance-runtime.stop-timeout-seconds` controls the graceful stop timeout before force-kill (unset uses Docker defaults).
   - Validation errors return 400 and stop command processing.

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -14,6 +14,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - Documented Brain authentication requirements for command endpoints.
 - Added Docker client connection settings for local or TCP Docker Engine access.
 - Added instance runtime settings for container image and workspace mount paths.
+- Added an optional instance stop timeout for graceful shutdowns.
 
 ## How to use / impact
 - Configure with environment variables or CLI args (`--node-agent.<key>=...`).
@@ -58,6 +59,7 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.instance-runtime.image` (`NODE_AGENT_INSTANCE_RUNTIME_IMAGE`)
   - `node-agent.instance-runtime.workspace-mount-path` (`NODE_AGENT_INSTANCE_RUNTIME_WORKSPACE_MOUNT_PATH`, default `/workspace`)
   - `node-agent.instance-runtime.working-dir` (`NODE_AGENT_INSTANCE_RUNTIME_WORKING_DIR`, defaults to workspace mount path)
+  - `node-agent.instance-runtime.stop-timeout-seconds` (`NODE_AGENT_INSTANCE_RUNTIME_STOP_TIMEOUT_SECONDS`, unset uses Docker defaults)
   - `node-agent.auth.header-name` (`NODE_AGENT_AUTH_HEADER_NAME`, default `X-Node-Token`)
   - `node-agent.auth.token-path` (`NODE_AGENT_AUTH_TOKEN_PATH`)
   - `node-agent.auth.cert-path` (`NODE_AGENT_AUTH_CERT_PATH`)
@@ -94,6 +96,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - `node-agent.instance-runtime.image` provides the default Docker image when the prepare payload does not supply `DOCKER_IMAGE`.
 - `node-agent.instance-runtime.workspace-mount-path` controls where the merged workspace is mounted inside the container.
 - `node-agent.instance-runtime.working-dir` overrides the container working directory (defaults to the workspace mount path).
+- `node-agent.instance-runtime.stop-timeout-seconds` controls the graceful stop timeout before the node agent force-kills a container (unset uses Docker defaults).
 - S3 configuration is required for template storage. When `node-agent.s3.endpoint` is set, the client
   uses path-style requests for local or custom S3 endpoints.
 

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -9,6 +9,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Added a local instance registry record written after successful preparation.
 - Added start/stop/destroy command handlers that send lifecycle callbacks to the Brain.
 - Start now creates and starts a Docker container from the prepared workspace and records its container id locally.
+- Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
 
 ## How to use / impact
 - `POST /api/instances/{instanceId}/prepare` with `NodePrepareInstanceRequest`.
@@ -32,9 +33,13 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
   - then calls back with `/api/nodes/{nodeId}/instances/{instanceId}/running`.
 - The container image defaults to `node-agent.instance-runtime.image` when not provided as `DOCKER_IMAGE`/`CONTAINER_IMAGE`/`IMAGE`.
 - The merged workspace is mounted at `node-agent.instance-runtime.workspace-mount-path` and the working directory defaults to the same path.
-- Stop/destroy currently acknowledge commands by calling back to the Brain:
-  - `/api/nodes/{nodeId}/instances/{instanceId}/stopped`
+- Stop/destroy acknowledge commands by calling back to the Brain:
+  - `/api/nodes/{nodeId}/instances/{instanceId}/stopped` (after stopping the container locally)
   - `/api/nodes/{nodeId}/instances/{instanceId}/destroyed`
+- Stop uses the container id recorded in `instance.json` and calls Docker to stop the container gracefully.
+- If the container is still running after the stop timeout, the node agent force-kills it.
+- The stop timeout is configured via `node-agent.instance-runtime.stop-timeout-seconds` (defaults to Docker's own timeout when unset).
+- The registry container status is updated to `stopped` after a successful stop.
 - `variables` and `variablesJson` are mutually exclusive. When `variablesJson` is provided, the node agent parses it as a JSON map.
 - Template cache lookups use `templateId` from the prepare payload as the cache key.
 
@@ -45,6 +50,10 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Start requires a container image from `variables` (`DOCKER_IMAGE`, `CONTAINER_IMAGE`, or `IMAGE`) or
   `node-agent.instance-runtime.image`; missing values fail the command.
 - Start fails if the prepared workspace or `instance.json` registry record is missing.
+- Stop fails if the registry is missing or does not contain a container id.
+- If the container is missing at stop time, the node agent logs a warning, marks the registry as stopped, and still sends the stop callback.
+- If the container disappears or stops between inspect and the Docker stop/kill calls, the node treats it as already stopped.
+- Stop errors attempt a `/failed` callback before returning the error.
 - Missing `portsJson` is allowed; port bindings fall back to `PORT`/`PORT_*` variables.
 - Invalid or missing port mappings result in a failed start and a `/failed` callback attempt.
 - If the `/running` callback fails after the container starts, the node logs the error but does not send `/failed`.

--- a/docs/node/operations/instance-registry.md
+++ b/docs/node/operations/instance-registry.md
@@ -6,6 +6,7 @@ Persist a local record of instance metadata after the node finishes preparing a 
 ## What changed
 - The prepare flow now writes an `instance.json` registry entry per instance.
 - The start flow updates the registry with the Docker container id.
+- The stop flow updates the registry with the latest container status.
 
 ## How to use / impact
 - Location: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances/<instanceId>/instance.json`.
@@ -16,7 +17,9 @@ Persist a local record of instance metadata after the node finishes preparing a 
   - template layer list from the prepare request
   - prepared timestamp
   - container id (set after the instance is started)
+  - container status and status timestamp (updated on start/stop)
 - The registry is overwritten on each successful prepare and updated again when the container id is recorded.
+- Container status updates are recorded when start marks the instance as `running` and stop marks it as `stopped`.
 
 ## Edge cases / risks
 - If the registry write fails, the prepare request fails and a `/failed` callback is attempted.

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -19,6 +19,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Added a health endpoint for basic node-agent diagnostics.
 - Added start/stop/destroy command handlers that send callbacks to the Brain.
 - Start now launches a Docker container using the prepared workspace and records the container id in the local registry.
+- Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
 - Added Brain authentication checks for command endpoints using a shared token or client certificate.
 
 ## How to use / impact
@@ -46,6 +47,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
     - `NODE_AGENT_INSTANCE_RUNTIME_IMAGE`
     - `NODE_AGENT_INSTANCE_RUNTIME_WORKSPACE_MOUNT_PATH`
     - `NODE_AGENT_INSTANCE_RUNTIME_WORKING_DIR`
+    - `NODE_AGENT_INSTANCE_RUNTIME_STOP_TIMEOUT_SECONDS`
     - `NODE_AGENT_VARIABLE_SUBSTITUTION_MAX_FILE_BYTES`
     - `NODE_AGENT_AUTH_HEADER_NAME`
     - `NODE_AGENT_AUTH_TOKEN_PATH`


### PR DESCRIPTION
## Description
- Implemented `InstanceStopService` to handle graceful instance shutdowns.
- Added support for stop timeouts with fallback to force-kill containers when necessary.
- Introduced `InstanceStopException` for error handling during instance stop operations.
- Updated `InstanceLifecycleService` to integrate stop functionality and callbacks.
- Enhanced registry to track container stop statuses and timestamps.
- Extended tests to cover stop scenarios and race conditions.
- Modified `NodeConfig` to validate stop timeout values and added related configurations.
- Updated documentation and contracts to outline the stop process and new configurations.

## Linked Issues
Closes #63

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
