### PR TITLE
feat(#64): add instance destroy service with container and workspace cleanup

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
@@ -171,6 +171,24 @@ public class InstanceRegistryService {
         );
     }
 
+    public void deleteRegistryIfExists(InstanceWorkspacePaths workspace) {
+        if (workspace == null) {
+            throw new InstanceRegistryException("instance workspace is required");
+        }
+        Path instanceRoot = Objects.requireNonNull(workspace.instanceRoot(), "instanceRoot");
+        if (!Files.isDirectory(instanceRoot)) {
+            return;
+        }
+        Path registryFile = instanceRoot.resolve(REGISTRY_FILENAME);
+        try {
+            if (Files.deleteIfExists(registryFile)) {
+                logger.info("Instance registry deleted. instanceId={} path={}", workspace.instanceId(), registryFile);
+            }
+        } catch (IOException ex) {
+            throw new InstanceRegistryException("Failed to delete instance registry at " + registryFile, ex);
+        }
+    }
+
     private void writeRegistry(Path registryFile, InstanceRegistryEntry entry) {
         Path parent = Objects.requireNonNull(registryFile, "registryFile").getParent();
         if (parent == null) {

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyException.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyException.java
@@ -1,0 +1,7 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import lombok.experimental.StandardException;
+
+@StandardException
+public class InstanceDestroyException extends RuntimeException {
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyService.java
@@ -1,0 +1,235 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.NotModifiedException;
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.docker.dto.DockerContainerStatus;
+import net.spookly.kodama.nodeagent.docker.service.DockerOperationException;
+import net.spookly.kodama.nodeagent.docker.service.DockerService;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryEntry;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryException;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceLayout;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceManager;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceDestroyService {
+
+    private static final Logger logger = LoggerFactory.getLogger(InstanceDestroyService.class);
+    private static final String CONTAINER_NAME_PREFIX = "kodama-instance-";
+    private static final String REGISTRY_FILENAME = "instance.json";
+
+    private final DockerService dockerService;
+    private final InstanceRegistryService registryService;
+    private final InstanceWorkspaceLayout workspaceLayout;
+    private final InstanceWorkspaceManager workspaceManager;
+    private final NodeConfig config;
+
+    public InstanceDestroyService(
+            DockerService dockerService,
+            InstanceRegistryService registryService,
+            InstanceWorkspaceLayout workspaceLayout,
+            InstanceWorkspaceManager workspaceManager,
+            NodeConfig config
+    ) {
+        this.dockerService = Objects.requireNonNull(dockerService, "dockerService");
+        this.registryService = Objects.requireNonNull(registryService, "registryService");
+        this.workspaceLayout = Objects.requireNonNull(workspaceLayout, "workspaceLayout");
+        this.workspaceManager = Objects.requireNonNull(workspaceManager, "workspaceManager");
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    public void destroyInstance(UUID instanceId) {
+        if (instanceId == null) {
+            throw new InstanceDestroyException("instanceId is required");
+        }
+        InstanceWorkspacePaths workspace = workspaceLayout.resolveWorkspace(instanceId.toString());
+        String containerId = resolveContainerId(instanceId, workspace);
+        stopAndRemoveContainer(instanceId, containerId);
+        deleteRegistryIfExists(instanceId, workspace);
+        deleteWorkspaceIfExists(instanceId, workspace);
+        logger.info(
+                "Instance destroy completed. instanceId={} containerId={} workspaceRoot={}",
+                instanceId,
+                valueOrDash(containerId),
+                workspace.instanceRoot()
+        );
+    }
+
+    private String resolveContainerId(UUID instanceId, InstanceWorkspacePaths workspace) {
+        if (workspace != null && Files.isDirectory(workspace.instanceRoot())) {
+            Path registryFile = workspace.instanceRoot().resolve(REGISTRY_FILENAME);
+            if (Files.isRegularFile(registryFile)) {
+                try {
+                    InstanceRegistryEntry registry = registryService.loadRegistry(workspace);
+                    if (registry != null && registry.instanceId() != null && !instanceId.equals(registry.instanceId())) {
+                        logger.warn(
+                                "Instance registry does not match instanceId during destroy. instanceId={} registryInstanceId={}",
+                                instanceId,
+                                registry.instanceId()
+                        );
+                    } else if (registry != null && hasText(registry.containerId())) {
+                        return registry.containerId().trim();
+                    }
+                } catch (InstanceRegistryException ex) {
+                    logger.warn(
+                            "Failed to read instance registry during destroy. instanceId={} path={}",
+                            instanceId,
+                            registryFile,
+                            ex
+                    );
+                }
+            } else {
+                logger.info("Instance registry missing during destroy. instanceId={} path={}", instanceId, registryFile);
+            }
+        } else {
+            logger.info("Instance workspace missing during destroy. instanceId={} workspaceRoot={}", instanceId, workspaceRootOrDash(workspace));
+        }
+        return CONTAINER_NAME_PREFIX + instanceId;
+    }
+
+    private void stopAndRemoveContainer(UUID instanceId, String containerId) {
+        if (!hasText(containerId)) {
+            logger.info("No container id resolved for destroy. instanceId={}", instanceId);
+            return;
+        }
+        String normalizedContainerId = containerId.trim();
+        DockerContainerStatus status = dockerService.inspectContainerIfExists(normalizedContainerId);
+        if (status == null) {
+            logger.info(
+                    "Instance container not found during destroy. instanceId={} containerId={}",
+                    instanceId,
+                    normalizedContainerId
+            );
+            return;
+        }
+        if (Boolean.TRUE.equals(status.running())) {
+            Integer stopTimeoutSeconds = resolveStopTimeoutSeconds();
+            try {
+                dockerService.stopContainer(normalizedContainerId, stopTimeoutSeconds);
+            } catch (DockerOperationException ex) {
+                if (!isStopRace(ex)) {
+                    throw ex;
+                }
+                logger.warn(
+                        "Instance container already stopped during destroy stop. instanceId={} containerId={}",
+                        instanceId,
+                        normalizedContainerId
+                );
+            }
+            DockerContainerStatus stoppedStatus = dockerService.inspectContainerIfExists(normalizedContainerId);
+            if (stoppedStatus != null && Boolean.TRUE.equals(stoppedStatus.running())) {
+                try {
+                    dockerService.killContainer(normalizedContainerId);
+                } catch (DockerOperationException ex) {
+                    if (!isStopRace(ex)) {
+                        throw ex;
+                    }
+                    logger.warn(
+                            "Instance container already stopped during destroy kill. instanceId={} containerId={}",
+                            instanceId,
+                            normalizedContainerId
+                    );
+                }
+                stoppedStatus = dockerService.inspectContainerIfExists(normalizedContainerId);
+                if (stoppedStatus != null && Boolean.TRUE.equals(stoppedStatus.running())) {
+                    throw new InstanceDestroyException("Container still running after force kill: " + normalizedContainerId);
+                }
+            }
+        }
+        try {
+            dockerService.removeContainer(normalizedContainerId, true, false);
+            logger.info(
+                    "Instance container removed during destroy. instanceId={} containerId={}",
+                    instanceId,
+                    normalizedContainerId
+            );
+        } catch (DockerOperationException ex) {
+            if (isContainerMissing(ex)) {
+                logger.info(
+                        "Instance container already removed during destroy. instanceId={} containerId={}",
+                        instanceId,
+                        normalizedContainerId
+                );
+                return;
+            }
+            throw ex;
+        }
+    }
+
+    private void deleteRegistryIfExists(UUID instanceId, InstanceWorkspacePaths workspace) {
+        if (workspace == null || workspace.instanceRoot() == null) {
+            return;
+        }
+        Path instanceRoot = workspace.instanceRoot();
+        if (!Files.isDirectory(instanceRoot)) {
+            return;
+        }
+        try {
+            registryService.deleteRegistryIfExists(workspace);
+        } catch (InstanceRegistryException ex) {
+            logger.warn("Failed to delete instance registry during destroy. instanceId={} path={}", instanceId, instanceRoot, ex);
+            throw ex;
+        }
+    }
+
+    private void deleteWorkspaceIfExists(UUID instanceId, InstanceWorkspacePaths workspace) {
+        if (workspace == null || workspace.instanceRoot() == null) {
+            return;
+        }
+        if (!Files.exists(workspace.instanceRoot())) {
+            logger.info("Instance workspace already removed during destroy. instanceId={} path={}", instanceId, workspace.instanceRoot());
+            return;
+        }
+        workspaceManager.deleteWorkspace(workspace);
+    }
+
+    private Integer resolveStopTimeoutSeconds() {
+        if (config.getInstanceRuntime() == null) {
+            return null;
+        }
+        return config.getInstanceRuntime().getStopTimeoutSeconds();
+    }
+
+    private boolean isStopRace(DockerOperationException ex) {
+        if (ex == null) {
+            return false;
+        }
+        Throwable cause = ex.getCause();
+        return cause instanceof NotFoundException || cause instanceof NotModifiedException;
+    }
+
+    private boolean isContainerMissing(DockerOperationException ex) {
+        if (ex == null) {
+            return false;
+        }
+        return ex.getCause() instanceof NotFoundException;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String valueOrDash(String value) {
+        if (!hasText(value)) {
+            return "-";
+        }
+        return value.trim();
+    }
+
+    private String workspaceRootOrDash(InstanceWorkspacePaths workspace) {
+        if (workspace == null || workspace.instanceRoot() == null) {
+            return "-";
+        }
+        return workspace.instanceRoot().toString();
+    }
+}

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
@@ -17,15 +17,18 @@ public class InstanceLifecycleService {
     private final InstanceCallbackService callbackService;
     private final InstanceStartService startService;
     private final InstanceStopService stopService;
+    private final InstanceDestroyService destroyService;
 
     public InstanceLifecycleService(
            InstanceCallbackService callbackService,
            InstanceStartService startService,
-           InstanceStopService stopService
+           InstanceStopService stopService,
+           InstanceDestroyService destroyService
     ) {
         this.callbackService = Objects.requireNonNull(callbackService, "callbackService");
         this.startService = Objects.requireNonNull(startService, "startService");
         this.stopService = Objects.requireNonNull(stopService, "stopService");
+        this.destroyService = Objects.requireNonNull(destroyService, "destroyService");
     }
 
     public void start(NodeInstanceCommandRequest request) {
@@ -76,6 +79,17 @@ public class InstanceLifecycleService {
     public void destroy(NodeInstanceCommandRequest request) {
         UUID instanceId = requireInstanceId(request);
         logger.info("Destroy command received. instanceId={} name={}", instanceId, valueOrDash(request.name()));
+        try {
+            destroyService.destroyInstance(instanceId);
+        } catch (RuntimeException ex) {
+            try {
+                callbackService.sendFailed(instanceId);
+            } catch (RuntimeException callbackEx) {
+                logger.warn("Destroy command failure callback failed. instanceId={}", instanceId, callbackEx);
+            }
+            logger.warn("Destroy command failed. instanceId={}", instanceId, ex);
+            throw ex;
+        }
         try {
             callbackService.sendDestroyed(instanceId);
             logger.info("Destroy command acknowledged. instanceId={}", instanceId);

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManager.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/workspace/InstanceWorkspaceManager.java
@@ -1,7 +1,11 @@
 package net.spookly.kodama.nodeagent.instance.workspace;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,5 +37,56 @@ public class InstanceWorkspaceManager {
         }
         logger.debug("Workspace ready for instance {} at {}", paths.instanceId(), paths.instanceRoot());
         return paths;
+    }
+
+    public void deleteWorkspace(InstanceWorkspacePaths workspace) {
+        if (workspace == null) {
+            throw new InstanceWorkspaceException("instance workspace is required");
+        }
+        Path instanceRoot = workspace.instanceRoot();
+        if (instanceRoot == null) {
+            throw new InstanceWorkspaceException("instance workspace root is required");
+        }
+        if (!Files.exists(instanceRoot)) {
+            return;
+        }
+        ensureWithinInstancesRoot(layout.getInstancesRoot(), instanceRoot);
+        try {
+            Files.walkFileTree(instanceRoot, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    Files.deleteIfExists(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ex) {
+            throw new InstanceWorkspaceException(
+                    "Failed to delete workspace for instance " + workspace.instanceId() + " at " + instanceRoot,
+                    ex
+            );
+        }
+        logger.info("Workspace deleted for instance {} at {}", workspace.instanceId(), instanceRoot);
+    }
+
+    private void ensureWithinInstancesRoot(Path instancesRoot, Path candidate) {
+        if (instancesRoot == null || candidate == null) {
+            throw new InstanceWorkspaceException("Instance workspace root path cannot be null");
+        }
+        Path normalizedRoot = instancesRoot.toAbsolutePath().normalize();
+        Path normalizedCandidate = candidate.toAbsolutePath().normalize();
+        if (!normalizedCandidate.startsWith(normalizedRoot)) {
+            throw new InstanceWorkspaceException(
+                    "Refusing to delete path outside instances root. root=" + normalizedRoot + " path=" + normalizedCandidate
+            );
+        }
     }
 }

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyServiceTest.java
@@ -1,0 +1,135 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.docker.dto.DockerContainerStatus;
+import net.spookly.kodama.nodeagent.docker.service.DockerService;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryEntry;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceLayout;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceManager;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class InstanceDestroyServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void destroyStopsRemovesContainerAndWorkspace() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        String containerId = "container-1";
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.toString());
+
+        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+        InstanceWorkspaceManager workspaceManager = new InstanceWorkspaceManager(layout);
+        InstanceWorkspacePaths workspace = workspaceManager.prepareWorkspace(instanceId.toString());
+
+        ObjectMapper objectMapper = objectMapper();
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper);
+        InstanceRegistryEntry entry = new InstanceRegistryEntry(
+                instanceId,
+                "instance-name",
+                null,
+                null,
+                Map.of(),
+                List.of(),
+                OffsetDateTime.now(),
+                containerId,
+                "running",
+                OffsetDateTime.now()
+        );
+        objectMapper.writeValue(workspace.instanceRoot().resolve("instance.json").toFile(), entry);
+
+        DockerService dockerService = mock(DockerService.class);
+        when(dockerService.inspectContainerIfExists(containerId))
+                .thenReturn(status(containerId, true, "running"), status(containerId, false, "exited"));
+
+        InstanceDestroyService service = new InstanceDestroyService(
+                dockerService,
+                registryService,
+                layout,
+                workspaceManager,
+                config
+        );
+
+        service.destroyInstance(instanceId);
+
+        verify(dockerService).stopContainer(containerId, null);
+        verify(dockerService).removeContainer(containerId, true, false);
+        assertThat(Files.exists(workspace.instanceRoot())).isFalse();
+    }
+
+    @Test
+    void destroySkipsMissingWorkspaceAndContainer() {
+        UUID instanceId = UUID.randomUUID();
+        String containerName = "kodama-instance-" + instanceId;
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.toString());
+
+        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+        InstanceWorkspaceManager workspaceManager = new InstanceWorkspaceManager(layout);
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+
+        DockerService dockerService = mock(DockerService.class);
+        when(dockerService.inspectContainerIfExists(containerName)).thenReturn(null);
+
+        InstanceDestroyService service = new InstanceDestroyService(
+                dockerService,
+                registryService,
+                layout,
+                workspaceManager,
+                config
+        );
+
+        assertThatNoException().isThrownBy(() -> service.destroyInstance(instanceId));
+
+        verify(dockerService, never()).stopContainer(anyString(), any());
+        verify(dockerService, never()).removeContainer(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    private DockerContainerStatus status(String containerId, Boolean running, String state) {
+        return new DockerContainerStatus(
+                containerId,
+                null,
+                null,
+                state,
+                running,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
@@ -18,7 +18,13 @@ class InstanceLifecycleServiceTest {
     private final InstanceCallbackService callbackService = mock(InstanceCallbackService.class);
     private final InstanceStartService startService = mock(InstanceStartService.class);
     private final InstanceStopService stopService = mock(InstanceStopService.class);
-    private final InstanceLifecycleService service = new InstanceLifecycleService(callbackService, startService, stopService);
+    private final InstanceDestroyService destroyService = mock(InstanceDestroyService.class);
+    private final InstanceLifecycleService service = new InstanceLifecycleService(
+            callbackService,
+            startService,
+            stopService,
+            destroyService
+    );
 
     @Test
     void startTriggersRunningCallback() {
@@ -46,6 +52,7 @@ class InstanceLifecycleServiceTest {
 
         service.destroy(new NodeInstanceCommandRequest(instanceId, "demo"));
 
+        verify(destroyService).destroyInstance(instanceId);
         verify(callbackService).sendDestroyed(instanceId);
     }
 
@@ -80,6 +87,20 @@ class InstanceLifecycleServiceTest {
                 .stopInstance(instanceId);
 
         assertThatThrownBy(() -> service.stop(new NodeInstanceCommandRequest(instanceId, "demo")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("boom");
+
+        verify(callbackService).sendFailed(instanceId);
+    }
+
+    @Test
+    void destroyFailureSendsFailedCallback() {
+        UUID instanceId = UUID.randomUUID();
+        doThrow(new RuntimeException("boom"))
+                .when(destroyService)
+                .destroyInstance(instanceId);
+
+        assertThatThrownBy(() -> service.destroy(new NodeInstanceCommandRequest(instanceId, "demo")))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("boom");
 

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -10,6 +10,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Added start/stop/destroy command handlers that send lifecycle callbacks to the Brain.
 - Start now creates and starts a Docker container from the prepared workspace and records its container id locally.
 - Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
+- Destroy now stops (or force-kills) the container, removes it, deletes the instance workspace, and removes the local registry entry.
 
 ## How to use / impact
 - `POST /api/instances/{instanceId}/prepare` with `NodePrepareInstanceRequest`.
@@ -35,8 +36,10 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - The merged workspace is mounted at `node-agent.instance-runtime.workspace-mount-path` and the working directory defaults to the same path.
 - Stop/destroy acknowledge commands by calling back to the Brain:
   - `/api/nodes/{nodeId}/instances/{instanceId}/stopped` (after stopping the container locally)
-  - `/api/nodes/{nodeId}/instances/{instanceId}/destroyed`
+  - `/api/nodes/{nodeId}/instances/{instanceId}/destroyed` (after container removal and workspace cleanup)
 - Stop uses the container id recorded in `instance.json` and calls Docker to stop the container gracefully.
+- Destroy resolves the container id from `instance.json` when available; if missing, it falls back to the container name `kodama-instance-<instanceId>`.
+- Destroy removes `instance.json` before deleting the instance workspace directory.
 - If the container is still running after the stop timeout, the node agent force-kills it.
 - The stop timeout is configured via `node-agent.instance-runtime.stop-timeout-seconds` (defaults to Docker's own timeout when unset).
 - The registry container status is updated to `stopped` after a successful stop.
@@ -52,8 +55,10 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Start fails if the prepared workspace or `instance.json` registry record is missing.
 - Stop fails if the registry is missing or does not contain a container id.
 - If the container is missing at stop time, the node agent logs a warning, marks the registry as stopped, and still sends the stop callback.
+- If the registry, container, or workspace is missing during destroy, the node agent treats it as already removed and continues cleanup.
 - If the container disappears or stops between inspect and the Docker stop/kill calls, the node treats it as already stopped.
 - Stop errors attempt a `/failed` callback before returning the error.
+- Destroy errors attempt a `/failed` callback before returning the error.
 - Missing `portsJson` is allowed; port bindings fall back to `PORT`/`PORT_*` variables.
 - Invalid or missing port mappings result in a failed start and a `/failed` callback attempt.
 - If the `/running` callback fails after the container starts, the node logs the error but does not send `/failed`.

--- a/docs/node/operations/instance-registry.md
+++ b/docs/node/operations/instance-registry.md
@@ -7,6 +7,7 @@ Persist a local record of instance metadata after the node finishes preparing a 
 - The prepare flow now writes an `instance.json` registry entry per instance.
 - The start flow updates the registry with the Docker container id.
 - The stop flow updates the registry with the latest container status.
+- The destroy flow deletes the `instance.json` registry entry before removing the workspace.
 
 ## How to use / impact
 - Location: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances/<instanceId>/instance.json`.
@@ -20,6 +21,7 @@ Persist a local record of instance metadata after the node finishes preparing a 
   - container status and status timestamp (updated on start/stop)
 - The registry is overwritten on each successful prepare and updated again when the container id is recorded.
 - Container status updates are recorded when start marks the instance as `running` and stop marks it as `stopped`.
+- Destroy removes the registry entry as part of instance cleanup.
 
 ## Edge cases / risks
 - If the registry write fails, the prepare request fails and a `/failed` callback is attempted.

--- a/docs/node/operations/instance-workspaces.md
+++ b/docs/node/operations/instance-workspaces.md
@@ -6,6 +6,7 @@ Describe how the node agent maps instance IDs to local workspace directories and
 ## What changed
 - Defined a deterministic on-disk layout for instance workspaces under `node-agent.workspace-dir`.
 - Added a helper that resolves and creates workspace folders for a given instance id.
+- Added a workspace delete helper used during instance destroy cleanup.
 
 ## How to use / impact
 - Workspace root: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances`.
@@ -15,6 +16,7 @@ Describe how the node agent maps instance IDs to local workspace directories and
   - `<instanceId>/temp` for transient runtime files.
   - `<instanceId>/instance.json` for the local instance registry record written after prepare.
 - The node agent creates these directories when `prepareWorkspace(instanceId)` is called.
+- The node agent deletes the entire instance workspace when `destroy` completes successfully.
 - `instanceId` must be a single path segment (no slashes or `..`).
 
 ## Edge cases / risks


### PR DESCRIPTION
## Description
- Implemented `InstanceDestroyService` to handle container stop/removal, workspace deletion, and registry cleanup.
- Added `InstanceDestroyException` for error handling during destroy operations.
- Extended `InstanceLifecycleService` to integrate destroy functionality and lifecycle callbacks.
- Updated workspace and registry components to support cleanup during instance destroy.
- Enhanced documentation with destroy flow details and edge case handling.
- Added comprehensive tests for `InstanceDestroyService` and lifecycle integration.

## Linked Issues
Closes #64

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
