### PR TITLE
feat(#66): add instance registry listing and workspace path tracking

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java
@@ -1,13 +1,17 @@
 package net.spookly.kodama.nodeagent.instance.controller;
 
+import java.util.List;
 import java.util.UUID;
 
 import net.spookly.kodama.nodeagent.instance.dto.NodeInstanceCommandRequest;
 import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceRequest;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryEntry;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
 import net.spookly.kodama.nodeagent.instance.service.InstanceLifecycleService;
 import net.spookly.kodama.nodeagent.instance.service.InstancePrepareService;
 import net.spookly.kodama.nodeagent.instance.service.InstancePrepareValidationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,13 +26,21 @@ public class InstanceCommandController {
 
     private final InstancePrepareService prepareService;
     private final InstanceLifecycleService lifecycleService;
+    private final InstanceRegistryService registryService;
 
     public InstanceCommandController(
             InstancePrepareService prepareService,
-            InstanceLifecycleService lifecycleService
+            InstanceLifecycleService lifecycleService,
+            InstanceRegistryService registryService
     ) {
         this.prepareService = prepareService;
         this.lifecycleService = lifecycleService;
+        this.registryService = registryService;
+    }
+
+    @GetMapping("/registry")
+    public List<InstanceRegistryEntry> listRegistries() {
+        return registryService.listRegistries();
     }
 
     @PostMapping("/{instanceId}/prepare")

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
@@ -17,6 +17,7 @@ public record InstanceRegistryEntry(
         OffsetDateTime preparedAt,
         String containerId,
         String containerStatus,
-        OffsetDateTime containerStatusUpdatedAt
+        OffsetDateTime containerStatusUpdatedAt,
+        String workspacePath
 ) {
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
@@ -7,15 +7,18 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceLayer;
 import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceRequest;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceLayout;
 import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,9 +31,11 @@ public class InstanceRegistryService {
     private static final String REGISTRY_FILENAME = "instance.json";
 
     private final ObjectMapper objectMapper;
+    private final InstanceWorkspaceLayout workspaceLayout;
 
-    public InstanceRegistryService(ObjectMapper objectMapper) {
+    public InstanceRegistryService(ObjectMapper objectMapper, InstanceWorkspaceLayout workspaceLayout) {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
+        this.workspaceLayout = Objects.requireNonNull(workspaceLayout, "workspaceLayout");
     }
 
     public void recordPrepared(
@@ -64,7 +69,8 @@ public class InstanceRegistryService {
                 OffsetDateTime.now(),
                 null,
                 null,
-                null
+                null,
+                resolveWorkspacePath(null, instanceRoot)
         );
 
         Path registryFile = instanceRoot.resolve(REGISTRY_FILENAME);
@@ -89,7 +95,11 @@ public class InstanceRegistryService {
             if (entry == null) {
                 throw new InstanceRegistryException("Instance registry is empty at " + registryFile);
             }
-            return entry;
+            InstanceRegistryEntry normalized = ensureWorkspacePath(entry, instanceRoot, registryFile, true);
+            if (normalized.instanceId() == null) {
+                throw new InstanceRegistryException("Instance registry has no instanceId at " + registryFile);
+            }
+            return normalized;
         } catch (IOException ex) {
             throw new InstanceRegistryException("Failed to read instance registry at " + registryFile, ex);
         }
@@ -122,7 +132,8 @@ public class InstanceRegistryService {
                 entry.preparedAt(),
                 containerId.trim(),
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                resolveWorkspacePath(entry.workspacePath(), workspace.instanceRoot())
         );
         Path registryFile = workspace.instanceRoot().resolve(REGISTRY_FILENAME);
         writeRegistry(registryFile, updated);
@@ -159,7 +170,8 @@ public class InstanceRegistryService {
                 entry.preparedAt(),
                 entry.containerId().trim(),
                 containerStatus.trim(),
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                resolveWorkspacePath(entry.workspacePath(), workspace.instanceRoot())
         );
         Path registryFile = workspace.instanceRoot().resolve(REGISTRY_FILENAME);
         writeRegistry(registryFile, updated);
@@ -187,6 +199,27 @@ public class InstanceRegistryService {
         } catch (IOException ex) {
             throw new InstanceRegistryException("Failed to delete instance registry at " + registryFile, ex);
         }
+    }
+
+    public List<InstanceRegistryEntry> listRegistries() {
+        Path instancesRoot = workspaceLayout.getInstancesRoot();
+        if (!Files.isDirectory(instancesRoot)) {
+            return List.of();
+        }
+        List<InstanceRegistryEntry> entries = new ArrayList<>();
+        try (Stream<Path> stream = Files.list(instancesRoot)) {
+            stream.filter(Files::isDirectory)
+                    .forEach(instanceRoot -> {
+                        InstanceRegistryEntry entry = loadRegistryForListing(instanceRoot);
+                        if (entry != null) {
+                            entries.add(entry);
+                        }
+                    });
+        } catch (IOException ex) {
+            throw new InstanceRegistryException("Failed to list instance registries at " + instancesRoot, ex);
+        }
+        entries.sort(Comparator.comparing(entry -> entry.instanceId().toString()));
+        return entries;
     }
 
     private void writeRegistry(Path registryFile, InstanceRegistryEntry entry) {
@@ -259,5 +292,109 @@ public class InstanceRegistryService {
             }
         }
         return layers;
+    }
+
+    private InstanceRegistryEntry loadRegistryForListing(Path instanceRoot) {
+        if (instanceRoot == null || !Files.isDirectory(instanceRoot)) {
+            return null;
+        }
+        Path registryFile = instanceRoot.resolve(REGISTRY_FILENAME);
+        if (!Files.isRegularFile(registryFile)) {
+            return null;
+        }
+        try {
+            InstanceRegistryEntry entry = objectMapper.readValue(registryFile.toFile(), InstanceRegistryEntry.class);
+            if (entry == null) {
+                logger.warn("Instance registry is empty at {}", registryFile);
+                return null;
+            }
+            if (entry.instanceId() == null) {
+                logger.warn("Instance registry has no instanceId at {}", registryFile);
+                return null;
+            }
+            return sanitizeForListing(entry, instanceRoot);
+        } catch (IOException ex) {
+            logger.warn("Failed to read instance registry at {}", registryFile, ex);
+            return null;
+        }
+    }
+
+    private InstanceRegistryEntry sanitizeForListing(InstanceRegistryEntry entry, Path instanceRoot) {
+        String relativeWorkspacePath = toRelativeWorkspacePath(instanceRoot);
+        return new InstanceRegistryEntry(
+                entry.instanceId(),
+                entry.name(),
+                entry.displayName(),
+                entry.portsJson(),
+                null,
+                entry.layers(),
+                entry.preparedAt(),
+                entry.containerId(),
+                entry.containerStatus(),
+                entry.containerStatusUpdatedAt(),
+                relativeWorkspacePath
+        );
+    }
+
+    private String toRelativeWorkspacePath(Path instanceRoot) {
+        if (instanceRoot == null) {
+            return null;
+        }
+        Path normalizedInstanceRoot = instanceRoot.toAbsolutePath().normalize();
+        Path workspaceRoot = workspaceLayout.getWorkspaceRoot();
+        if (workspaceRoot != null) {
+            Path normalizedWorkspaceRoot = workspaceRoot.toAbsolutePath().normalize();
+            if (normalizedInstanceRoot.startsWith(normalizedWorkspaceRoot)) {
+                return normalizedWorkspaceRoot.relativize(normalizedInstanceRoot).toString();
+            }
+        }
+        Path instancesRoot = workspaceLayout.getInstancesRoot();
+        if (instancesRoot != null) {
+            Path normalizedInstancesRoot = instancesRoot.toAbsolutePath().normalize();
+            if (normalizedInstanceRoot.startsWith(normalizedInstancesRoot)) {
+                Path relative = normalizedInstancesRoot.relativize(normalizedInstanceRoot);
+                return normalizedInstancesRoot.getFileName().resolve(relative).toString();
+            }
+        }
+        return null;
+    }
+
+    private InstanceRegistryEntry ensureWorkspacePath(
+            InstanceRegistryEntry entry,
+            Path instanceRoot,
+            Path registryFile,
+            boolean persistIfUpdated
+    ) {
+        String resolvedPath = resolveWorkspacePath(entry.workspacePath(), instanceRoot);
+        if (Objects.equals(resolvedPath, entry.workspacePath())) {
+            return entry;
+        }
+        InstanceRegistryEntry updated = new InstanceRegistryEntry(
+                entry.instanceId(),
+                entry.name(),
+                entry.displayName(),
+                entry.portsJson(),
+                entry.variables(),
+                entry.layers(),
+                entry.preparedAt(),
+                entry.containerId(),
+                entry.containerStatus(),
+                entry.containerStatusUpdatedAt(),
+                resolvedPath
+        );
+        if (persistIfUpdated && registryFile != null) {
+            writeRegistry(registryFile, updated);
+        }
+        return updated;
+    }
+
+    private String resolveWorkspacePath(String existing, Path instanceRoot) {
+        if (instanceRoot != null) {
+            return instanceRoot.toAbsolutePath().normalize().toString();
+        }
+        if (existing != null && !existing.isBlank()) {
+            return existing.trim();
+        }
+        return null;
     }
 }

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
@@ -48,8 +48,9 @@ class InstanceRegistryServiceTest {
                 layers
         );
 
-        InstanceWorkspacePaths workspace = prepareWorkspace(instanceId.toString());
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, instanceId.toString());
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
 
         registryService.recordPrepared(workspace, request, layers, variables);
 
@@ -68,6 +69,7 @@ class InstanceRegistryServiceTest {
         assertThat(entry.containerId()).isNull();
         assertThat(entry.containerStatus()).isNull();
         assertThat(entry.containerStatusUpdatedAt()).isNull();
+        assertThat(entry.workspacePath()).isEqualTo(workspace.instanceRoot().toAbsolutePath().normalize().toString());
     }
 
     @Test
@@ -92,8 +94,9 @@ class InstanceRegistryServiceTest {
                 null,
                 layers
         );
-        InstanceWorkspacePaths workspace = prepareWorkspace("different-instance");
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, "different-instance");
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
 
         assertThatThrownBy(() -> registryService.recordPrepared(workspace, request, layers, Map.of()))
                 .isInstanceOf(InstanceRegistryException.class)
@@ -122,8 +125,9 @@ class InstanceRegistryServiceTest {
                 null,
                 layers
         );
-        InstanceWorkspacePaths workspace = prepareWorkspace(instanceId.toString());
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, instanceId.toString());
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
 
         registryService.recordPrepared(workspace, request, layers, Map.of());
         registryService.recordContainerId(workspace, instanceId, "container-123");
@@ -133,6 +137,7 @@ class InstanceRegistryServiceTest {
         assertThat(entry.containerId()).isEqualTo("container-123");
         assertThat(entry.containerStatus()).isEqualTo("running");
         assertThat(entry.containerStatusUpdatedAt()).isNotNull();
+        assertThat(entry.workspacePath()).isEqualTo(workspace.instanceRoot().toAbsolutePath().normalize().toString());
     }
 
     @Test
@@ -157,8 +162,9 @@ class InstanceRegistryServiceTest {
                 null,
                 layers
         );
-        InstanceWorkspacePaths workspace = prepareWorkspace(instanceId.toString());
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, instanceId.toString());
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
 
         registryService.recordPrepared(workspace, request, layers, Map.of());
         registryService.recordContainerId(workspace, instanceId, "container-123");
@@ -169,14 +175,74 @@ class InstanceRegistryServiceTest {
         assertThat(entry.containerId()).isEqualTo("container-123");
         assertThat(entry.containerStatus()).isEqualTo("stopped");
         assertThat(entry.containerStatusUpdatedAt()).isNotNull();
+        assertThat(entry.workspacePath()).isEqualTo(workspace.instanceRoot().toAbsolutePath().normalize().toString());
     }
 
-    private InstanceWorkspacePaths prepareWorkspace(String instanceId) {
-        NodeConfig config = new NodeConfig();
-        config.setWorkspaceDir(tempDir.resolve("workspace-root").toString());
-        InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
+    @Test
+    void listRegistriesReturnsKnownInstances() {
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
+        NodePrepareInstanceLayer layer = new NodePrepareInstanceLayer(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "1.0.0",
+                "checksum",
+                "s3/key.tgz",
+                null,
+                0
+        );
+        List<NodePrepareInstanceLayer> layers = List.of(layer);
+
+        UUID firstId = UUID.randomUUID();
+        UUID secondId = UUID.randomUUID();
+        InstanceWorkspacePaths firstWorkspace = prepareWorkspace(layout, firstId.toString());
+        InstanceWorkspacePaths secondWorkspace = prepareWorkspace(layout, secondId.toString());
+
+        NodePrepareInstanceRequest firstRequest = new NodePrepareInstanceRequest(
+                firstId,
+                "first",
+                null,
+                null,
+                Map.of(),
+                null,
+                layers
+        );
+        NodePrepareInstanceRequest secondRequest = new NodePrepareInstanceRequest(
+                secondId,
+                "second",
+                null,
+                null,
+                Map.of(),
+                null,
+                layers
+        );
+
+        registryService.recordPrepared(firstWorkspace, firstRequest, layers, Map.of());
+        registryService.recordPrepared(secondWorkspace, secondRequest, layers, Map.of());
+
+        List<InstanceRegistryEntry> entries = registryService.listRegistries();
+
+        assertThat(entries)
+                .extracting(InstanceRegistryEntry::instanceId)
+                .containsExactlyInAnyOrder(firstId, secondId);
+        assertThat(entries)
+                .allMatch(entry -> entry.workspacePath() != null && !entry.workspacePath().isBlank());
+        assertThat(entries)
+                .allMatch(entry -> entry.variables() == null);
+        assertThat(entries)
+                .anyMatch(entry -> entry.workspacePath().equals(Path.of("instances", firstId.toString()).toString()))
+                .anyMatch(entry -> entry.workspacePath().equals(Path.of("instances", secondId.toString()).toString()));
+    }
+
+    private InstanceWorkspacePaths prepareWorkspace(InstanceWorkspaceLayout layout, String instanceId) {
         InstanceWorkspaceManager workspaceManager = new InstanceWorkspaceManager(layout);
         return workspaceManager.prepareWorkspace(instanceId);
+    }
+
+    private InstanceWorkspaceLayout workspaceLayout() {
+        NodeConfig config = new NodeConfig();
+        config.setWorkspaceDir(tempDir.resolve("workspace-root").toString());
+        return new InstanceWorkspaceLayout(config);
     }
 
     private ObjectMapper objectMapper() {

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceDestroyServiceTest.java
@@ -47,7 +47,7 @@ class InstanceDestroyServiceTest {
         InstanceWorkspacePaths workspace = workspaceManager.prepareWorkspace(instanceId.toString());
 
         ObjectMapper objectMapper = objectMapper();
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper);
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper, layout);
         InstanceRegistryEntry entry = new InstanceRegistryEntry(
                 instanceId,
                 "instance-name",
@@ -58,7 +58,8 @@ class InstanceDestroyServiceTest {
                 OffsetDateTime.now(),
                 containerId,
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                workspace.instanceRoot().toAbsolutePath().normalize().toString()
         );
         objectMapper.writeValue(workspace.instanceRoot().resolve("instance.json").toFile(), entry);
 
@@ -90,7 +91,7 @@ class InstanceDestroyServiceTest {
 
         InstanceWorkspaceLayout layout = new InstanceWorkspaceLayout(config);
         InstanceWorkspaceManager workspaceManager = new InstanceWorkspaceManager(layout);
-        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper());
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
 
         DockerService dockerService = mock(DockerService.class);
         when(dockerService.inspectContainerIfExists(containerName)).thenReturn(null);

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePortBindingsResolverTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePortBindingsResolverTest.java
@@ -28,6 +28,7 @@ class InstancePortBindingsResolverTest {
                 OffsetDateTime.now(),
                 null,
                 null,
+                null,
                 null
         );
 
@@ -49,6 +50,7 @@ class InstancePortBindingsResolverTest {
                 Map.of("PORT", "25565"),
                 List.of(),
                 OffsetDateTime.now(),
+                null,
                 null,
                 null,
                 null
@@ -76,6 +78,7 @@ class InstancePortBindingsResolverTest {
                 variables,
                 List.of(),
                 OffsetDateTime.now(),
+                null,
                 null,
                 null,
                 null

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStartServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStartServiceTest.java
@@ -57,7 +57,8 @@ class InstanceStartServiceTest {
                 OffsetDateTime.now(),
                 null,
                 null,
-                null
+                null,
+                instanceRoot.toAbsolutePath().normalize().toString()
         );
 
         DockerService dockerService = mock(DockerService.class);

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceStopServiceTest.java
@@ -47,7 +47,8 @@ class InstanceStopServiceTest {
                 OffsetDateTime.now(),
                 containerId,
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                null
         );
 
         DockerService dockerService = mock(DockerService.class);
@@ -91,7 +92,8 @@ class InstanceStopServiceTest {
                 OffsetDateTime.now(),
                 containerId,
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                null
         );
 
         DockerService dockerService = mock(DockerService.class);
@@ -138,7 +140,8 @@ class InstanceStopServiceTest {
                 OffsetDateTime.now(),
                 containerId,
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                null
         );
 
         DockerService dockerService = mock(DockerService.class);
@@ -181,7 +184,8 @@ class InstanceStopServiceTest {
                 OffsetDateTime.now(),
                 containerId,
                 "running",
-                OffsetDateTime.now()
+                OffsetDateTime.now(),
+                null
         );
 
         DockerService dockerService = mock(DockerService.class);

--- a/contracts/nodeapi.yml
+++ b/contracts/nodeapi.yml
@@ -111,6 +111,31 @@ endpoints:
       "200": OK
       "400": Bad Request
 
+  instanceRegistryList:
+    method: GET
+    path: /api/instances/registry
+    summary: List local instance registry entries
+    response:
+      instances:
+        - instanceId: uuid
+          name: string|null
+          displayName: string|null
+          portsJson: string|null
+          variables: map<string,string>|null (redacted in registry listing)
+          layers:
+            - templateVersionId: uuid
+              templateId: uuid
+              version: string
+              checksum: string
+              s3Key: string
+              metadataJson: string|null
+              orderIndex: int32
+          preparedAt: datetime|null
+          containerId: string|null
+          containerStatus: string|null
+          containerStatusUpdatedAt: datetime|null
+          workspacePath: string|null (relative to node-agent.workspace-dir)
+
 callbacks:
   prepared:
     method: POST
@@ -132,5 +157,7 @@ notes:
   - Dev-mode updates are in-memory only; restart resets to configured defaults.
   - Start now creates and starts a Docker container for the prepared workspace and records the container id locally.
   - Stop now resolves the container id from the local registry, stops the container, and updates the registry state to stopped.
+  - `GET /api/instances/registry` returns registry entries derived from instance workspaces on disk.
+  - Registry listings omit variables and return workspacePath relative to `node-agent.workspace-dir`.
   - `node-agent.instance-runtime.stop-timeout-seconds` controls the graceful stop timeout before force-kill (unset uses Docker defaults).
   - Validation errors return 400 and stop command processing.

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -11,6 +11,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Start now creates and starts a Docker container from the prepared workspace and records its container id locally.
 - Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
 - Destroy now stops (or force-kills) the container, removes it, deletes the instance workspace, and removes the local registry entry.
+- Added a local registry listing endpoint for listing known instance records.
 
 ## How to use / impact
 - `POST /api/instances/{instanceId}/prepare` with `NodePrepareInstanceRequest`.
@@ -24,6 +25,8 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - `POST /api/instances/{instanceId}/start` with `NodeInstanceCommandRequest`.
 - `POST /api/instances/{instanceId}/stop` with `NodeInstanceCommandRequest`.
 - `POST /api/instances/{instanceId}/destroy` with `NodeInstanceCommandRequest`.
+- `GET /api/instances/registry` to list locally known instance registry entries.
+- Registry listing requires the same Brain authentication as other instance command endpoints.
 - `NodeInstanceCommandRequest` requires `instanceId` and accepts an optional `name` for logging.
 - Start now:
   - reads `instance.json` from the workspace,
@@ -40,6 +43,8 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Stop uses the container id recorded in `instance.json` and calls Docker to stop the container gracefully.
 - Destroy resolves the container id from `instance.json` when available; if missing, it falls back to the container name `kodama-instance-<instanceId>`.
 - Destroy removes `instance.json` before deleting the instance workspace directory.
+- Registry entries include the instance workspace path (relative to `node-agent.workspace-dir`) and last known container status.
+- Registry listings omit `variables` to avoid leaking runtime secrets.
 - If the container is still running after the stop timeout, the node agent force-kills it.
 - The stop timeout is configured via `node-agent.instance-runtime.stop-timeout-seconds` (defaults to Docker's own timeout when unset).
 - The registry container status is updated to `stopped` after a successful stop.

--- a/docs/node/operations/instance-workspaces.md
+++ b/docs/node/operations/instance-workspaces.md
@@ -7,6 +7,7 @@ Describe how the node agent maps instance IDs to local workspace directories and
 - Defined a deterministic on-disk layout for instance workspaces under `node-agent.workspace-dir`.
 - Added a helper that resolves and creates workspace folders for a given instance id.
 - Added a workspace delete helper used during instance destroy cleanup.
+- Recorded the workspace path inside the per-instance registry file for local lookups.
 
 ## How to use / impact
 - Workspace root: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances`.
@@ -14,10 +15,12 @@ Describe how the node agent maps instance IDs to local workspace directories and
   - `<instanceId>/merged` for merged template/config output.
   - `<instanceId>/logs` for instance logs.
   - `<instanceId>/temp` for transient runtime files.
-  - `<instanceId>/instance.json` for the local instance registry record written after prepare.
+  - `<instanceId>/instance.json` for the local instance registry record written after prepare (includes workspace path and container status metadata).
 - The node agent creates these directories when `prepareWorkspace(instanceId)` is called.
 - The node agent deletes the entire instance workspace when `destroy` completes successfully.
 - `instanceId` must be a single path segment (no slashes or `..`).
+- Local registry entries can be enumerated via `GET /api/instances/registry`.
+- Registry listings return workspace paths relative to `node-agent.workspace-dir` and omit `variables`.
 
 ## Edge cases / risks
 - If `node-agent.workspace-dir` is blank or invalid, workspace resolution fails with a clear error.

--- a/docs/node/overview.md
+++ b/docs/node/overview.md
@@ -20,6 +20,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
 - Added start/stop/destroy command handlers that send callbacks to the Brain.
 - Start now launches a Docker container using the prepared workspace and records the container id in the local registry.
 - Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
+- Added a local registry listing endpoint and recorded workspace paths in instance registry entries.
 - Added Brain authentication checks for command endpoints using a shared token or client certificate.
 
 ## How to use / impact
@@ -59,6 +60,7 @@ The Node Agent is a lightweight Java service that runs on each node and executes
     - `NODE_AGENT_S3_SECRET_KEY`
 - See `docs/node/operations/configuration.md` for the full mapping.
 - Health check is available at `GET /health` on the configured node-agent HTTP port.
+- Local instance registry listing is available at `GET /api/instances/registry` (Brain auth required) and returns workspace paths relative to `node-agent.workspace-dir`.
 
 ## Edge cases / risks
 - If required configuration is missing, the node agent will exit on startup with a clear error.


### PR DESCRIPTION
## Description
- Implemented a local registry listing endpoint (`GET /api/instances/registry`) to enumerate instance records.
- Updated the registry to include workspace paths relative to `node-agent.workspace-dir`.
- Enhanced `InstanceRegistryService` to support retrieving and sanitizing entries for listings.
- Adjusted tests to validate registry listing behavior and workspace path updates.
- Updated documentation with instructions for using the registry listing endpoint and associated metadata changes.

## Linked Issues
Closes #66

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
