### PR TITLE
feature(#65): rename NodeCallbackClient to BrainCallbackClient, add retry logic for lifecycle callbacks, and update configurations

### DIFF
--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/config/NodeConfig.java
@@ -29,6 +29,7 @@ public class NodeConfig {
     private TemplateCacheLimits templateCacheLimits = new TemplateCacheLimits();
     private VariableSubstitution variableSubstitution = new VariableSubstitution();
     private InstanceRuntime instanceRuntime = new InstanceRuntime();
+    private InstanceCallbacks instanceCallbacks = new InstanceCallbacks();
 
     public void validate() {
         List<String> errors = new ArrayList<>();
@@ -69,6 +70,16 @@ public class NodeConfig {
             Integer stopTimeoutSeconds = instanceRuntime.getStopTimeoutSeconds();
             if (stopTimeoutSeconds != null && stopTimeoutSeconds < 0) {
                 errors.add("node-agent.instance-runtime.stop-timeout-seconds must be 0 or greater");
+            }
+        }
+        if (instanceCallbacks == null) {
+            errors.add("node-agent.instance-callbacks is required");
+        } else {
+            if (instanceCallbacks.getMaxAttempts() < 1) {
+                errors.add("node-agent.instance-callbacks.max-attempts must be at least 1");
+            }
+            if (instanceCallbacks.getRetryBackoffMillis() < 0) {
+                errors.add("node-agent.instance-callbacks.retry-backoff-millis must be 0 or greater");
             }
         }
         if (docker == null) {
@@ -275,6 +286,14 @@ public class NodeConfig {
         this.instanceRuntime = instanceRuntime == null ? new InstanceRuntime() : instanceRuntime;
     }
 
+    public InstanceCallbacks getInstanceCallbacks() {
+        return instanceCallbacks;
+    }
+
+    public void setInstanceCallbacks(InstanceCallbacks instanceCallbacks) {
+        this.instanceCallbacks = instanceCallbacks == null ? new InstanceCallbacks() : instanceCallbacks;
+    }
+
     public static class Auth {
 
         private String tokenPath;
@@ -467,6 +486,28 @@ public class NodeConfig {
 
         public void setStopTimeoutSeconds(Integer stopTimeoutSeconds) {
             this.stopTimeoutSeconds = stopTimeoutSeconds;
+        }
+    }
+
+    public static class InstanceCallbacks {
+
+        private int maxAttempts = 1;
+        private long retryBackoffMillis;
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+
+        public long getRetryBackoffMillis() {
+            return retryBackoffMillis;
+        }
+
+        public void setRetryBackoffMillis(long retryBackoffMillis) {
+            this.retryBackoffMillis = retryBackoffMillis;
         }
     }
 

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/BrainCallbackClient.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/BrainCallbackClient.java
@@ -19,14 +19,14 @@ import org.apache.hc.core5.util.Timeout;
 import org.springframework.stereotype.Component;
 
 @Component
-public class NodeCallbackClient {
+public class BrainCallbackClient {
 
     private static final Timeout CONNECT_TIMEOUT = Timeout.ofSeconds(5);
     private static final Timeout RESPONSE_TIMEOUT = Timeout.ofSeconds(10);
 
     private final CloseableHttpClient httpClient;
 
-    public NodeCallbackClient() {
+    public BrainCallbackClient() {
         this.httpClient = HttpClients.custom()
                 .setDefaultRequestConfig(RequestConfig.custom()
                         .setConnectTimeout(CONNECT_TIMEOUT)

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackService.java
@@ -7,21 +7,25 @@ import net.spookly.kodama.nodeagent.config.NodeConfig;
 import net.spookly.kodama.nodeagent.instance.service.InstancePrepareException;
 import net.spookly.kodama.nodeagent.registration.NodeAuthTokenReader;
 import net.spookly.kodama.nodeagent.registration.NodeRegistrationState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class InstanceCallbackService {
 
+    private static final Logger logger = LoggerFactory.getLogger(InstanceCallbackService.class);
+
     private final NodeConfig config;
     private final NodeRegistrationState registrationState;
     private final NodeAuthTokenReader tokenReader;
-    private final NodeCallbackClient callbackClient;
+    private final BrainCallbackClient callbackClient;
 
     public InstanceCallbackService(
             NodeConfig config,
             NodeRegistrationState registrationState,
             NodeAuthTokenReader tokenReader,
-            NodeCallbackClient callbackClient
+            BrainCallbackClient callbackClient
     ) {
         this.config = config;
         this.registrationState = registrationState;
@@ -60,7 +64,88 @@ public class InstanceCallbackService {
         if (authToken == null || authToken.isBlank()) {
             authToken = null;
         }
-        callbackClient.sendCallback(endpoint, headerName, authToken);
+        int maxAttempts = resolveMaxAttempts();
+        long backoffMillis = resolveBackoffMillis();
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                callbackClient.sendCallback(endpoint, headerName, authToken);
+                if (attempt > 1) {
+                    logger.info(
+                            "Instance callback succeeded after retry attempt {} action={} instanceId={}",
+                            attempt,
+                            action,
+                            instanceId
+                    );
+                }
+                return;
+            } catch (RuntimeException ex) {
+                if (attempt >= maxAttempts) {
+                    logger.warn(
+                            "Instance callback failed after {} attempts action={} instanceId={} endpoint={}",
+                            maxAttempts,
+                            action,
+                            instanceId,
+                            endpoint,
+                            ex
+                    );
+                    throw ex;
+                }
+                logger.warn(
+                        "Instance callback attempt {} failed, retrying in {}ms action={} instanceId={} endpoint={}",
+                        attempt,
+                        backoffMillis,
+                        action,
+                        instanceId,
+                        endpoint,
+                        ex
+                );
+                if (!sleep(backoffMillis)) {
+                    throw ex;
+                }
+                backoffMillis = nextBackoffMillis(backoffMillis);
+            }
+        }
+    }
+
+    private int resolveMaxAttempts() {
+        NodeConfig.InstanceCallbacks callbacks = config.getInstanceCallbacks();
+        if (callbacks == null) {
+            return 1;
+        }
+        return Math.max(1, callbacks.getMaxAttempts());
+    }
+
+    private long resolveBackoffMillis() {
+        NodeConfig.InstanceCallbacks callbacks = config.getInstanceCallbacks();
+        if (callbacks == null) {
+            return 0L;
+        }
+        return Math.max(0L, callbacks.getRetryBackoffMillis());
+    }
+
+    private long nextBackoffMillis(long backoffMillis) {
+        if (backoffMillis <= 0) {
+            return 0L;
+        }
+        long next = backoffMillis * 2;
+        if (next < 0) {
+            return backoffMillis;
+        }
+        return next;
+    }
+
+    private boolean sleep(long backoffMillis) {
+        if (backoffMillis <= 0) {
+            return true;
+        }
+        try {
+            Thread.sleep(backoffMillis);
+            return true;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.warn("Instance callback retry interrupted");
+            return false;
+        }
     }
 
     private UUID resolveNodeId() {

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleService.java
@@ -72,7 +72,6 @@ public class InstanceLifecycleService {
             logger.info("Stop command acknowledged. instanceId={}", instanceId);
         } catch (RuntimeException ex) {
             logger.warn("Stop command callback failed. instanceId={}", instanceId, ex);
-            throw ex;
         }
     }
 
@@ -95,7 +94,6 @@ public class InstanceLifecycleService {
             logger.info("Destroy command acknowledged. instanceId={}", instanceId);
         } catch (RuntimeException ex) {
             logger.warn("Destroy command callback failed. instanceId={}", instanceId, ex);
-            throw ex;
         }
     }
 

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstancePrepareService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/service/InstancePrepareService.java
@@ -88,11 +88,10 @@ public class InstancePrepareService {
 
         try {
             callbackService.sendPrepared(instanceId);
-            logger.info("Instance preparation complete. instanceId={} layers={}", instanceId, layerCount);
         } catch (RuntimeException ex) {
             logger.warn("Prepared callback failed. instanceId={}", instanceId, ex);
-            throw ex;
         }
+        logger.info("Instance preparation complete. instanceId={} layers={}", instanceId, layerCount);
     }
 
     private TemplateLayerSource resolveLayerSource(NodePrepareInstanceLayer layer) {

--- a/backend/node-agent/src/main/resources/application.yml
+++ b/backend/node-agent/src/main/resources/application.yml
@@ -46,6 +46,9 @@ node-agent:
     workspace-mount-path: ${NODE_AGENT_INSTANCE_RUNTIME_WORKSPACE_MOUNT_PATH:/workspace}
     working-dir: ${NODE_AGENT_INSTANCE_RUNTIME_WORKING_DIR:}
     stop-timeout-seconds: ${NODE_AGENT_INSTANCE_RUNTIME_STOP_TIMEOUT_SECONDS:}
+  instance-callbacks:
+    max-attempts: ${NODE_AGENT_INSTANCE_CALLBACKS_MAX_ATTEMPTS:1}
+    retry-backoff-millis: ${NODE_AGENT_INSTANCE_CALLBACKS_RETRY_BACKOFF_MILLIS:500}
   auth:
     header-name: ${NODE_AGENT_AUTH_HEADER_NAME:X-Node-Token}
     token-path: ${NODE_AGENT_AUTH_TOKEN_PATH:}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/callback/InstanceCallbackServiceTest.java
@@ -1,0 +1,104 @@
+package net.spookly.kodama.nodeagent.instance.callback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.UUID;
+
+import net.spookly.kodama.nodeagent.config.NodeConfig;
+import net.spookly.kodama.nodeagent.registration.NodeAuthTokenReader;
+import net.spookly.kodama.nodeagent.registration.NodeRegistrationResponse;
+import net.spookly.kodama.nodeagent.registration.NodeRegistrationState;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class InstanceCallbackServiceTest {
+
+    @Test
+    void sendRunningRetriesUntilSuccess() {
+        NodeConfig config = buildConfig(3, 0);
+        NodeRegistrationState registrationState = buildRegistrationState();
+        NodeAuthTokenReader tokenReader = mock(NodeAuthTokenReader.class);
+        when(tokenReader.readToken()).thenReturn(null);
+        BrainCallbackClient callbackClient = mock(BrainCallbackClient.class);
+        doThrow(new RuntimeException("boom"))
+                .doThrow(new RuntimeException("boom"))
+                .doNothing()
+                .when(callbackClient)
+                .sendCallback(any(), anyString(), any());
+
+        InstanceCallbackService service = new InstanceCallbackService(
+                config,
+                registrationState,
+                tokenReader,
+                callbackClient
+        );
+        UUID instanceId = UUID.randomUUID();
+
+        assertThatNoException().isThrownBy(() -> service.sendRunning(instanceId));
+
+        ArgumentCaptor<URI> endpointCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(callbackClient, times(3)).sendCallback(endpointCaptor.capture(), anyString(), any());
+        URI endpoint = endpointCaptor.getValue();
+        assertThat(endpoint.toString())
+                .contains("/api/nodes/")
+                .contains("/instances/" + instanceId + "/running");
+    }
+
+    @Test
+    void sendRunningStopsAfterMaxAttempts() {
+        NodeConfig config = buildConfig(2, 0);
+        NodeRegistrationState registrationState = buildRegistrationState();
+        NodeAuthTokenReader tokenReader = mock(NodeAuthTokenReader.class);
+        when(tokenReader.readToken()).thenReturn(null);
+        BrainCallbackClient callbackClient = mock(BrainCallbackClient.class);
+        doThrow(new RuntimeException("boom"))
+                .when(callbackClient)
+                .sendCallback(any(), anyString(), any());
+
+        InstanceCallbackService service = new InstanceCallbackService(
+                config,
+                registrationState,
+                tokenReader,
+                callbackClient
+        );
+        UUID instanceId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> service.sendRunning(instanceId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("boom");
+
+        verify(callbackClient, times(2)).sendCallback(any(), anyString(), any());
+    }
+
+    private NodeConfig buildConfig(int maxAttempts, long backoffMillis) {
+        NodeConfig config = new NodeConfig();
+        config.setBrainBaseUrl("http://brain");
+        NodeConfig.Auth auth = new NodeConfig.Auth();
+        auth.setHeaderName("X-Node-Token");
+        config.setAuth(auth);
+        NodeConfig.InstanceCallbacks callbacks = new NodeConfig.InstanceCallbacks();
+        callbacks.setMaxAttempts(maxAttempts);
+        callbacks.setRetryBackoffMillis(backoffMillis);
+        config.setInstanceCallbacks(callbacks);
+        return config;
+    }
+
+    private NodeRegistrationState buildRegistrationState() {
+        NodeRegistrationState registrationState = new NodeRegistrationState();
+        NodeRegistrationResponse response = new NodeRegistrationResponse();
+        response.setNodeId(UUID.randomUUID());
+        response.setHeartbeatIntervalSeconds(10);
+        registrationState.update(response);
+        return registrationState;
+    }
+}

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstanceLifecycleServiceTest.java
@@ -120,4 +120,32 @@ class InstanceLifecycleServiceTest {
         verify(callbackService).sendRunning(instanceId);
         verify(callbackService, never()).sendFailed(instanceId);
     }
+
+    @Test
+    void stopCallbackFailureDoesNotThrow() {
+        UUID instanceId = UUID.randomUUID();
+        doThrow(new RuntimeException("callback boom"))
+                .when(callbackService)
+                .sendStopped(instanceId);
+
+        assertThatNoException().isThrownBy(() -> service.stop(new NodeInstanceCommandRequest(instanceId, "demo")));
+
+        verify(stopService).stopInstance(instanceId);
+        verify(callbackService).sendStopped(instanceId);
+        verify(callbackService, never()).sendFailed(instanceId);
+    }
+
+    @Test
+    void destroyCallbackFailureDoesNotThrow() {
+        UUID instanceId = UUID.randomUUID();
+        doThrow(new RuntimeException("callback boom"))
+                .when(callbackService)
+                .sendDestroyed(instanceId);
+
+        assertThatNoException().isThrownBy(() -> service.destroy(new NodeInstanceCommandRequest(instanceId, "demo")));
+
+        verify(destroyService).destroyInstance(instanceId);
+        verify(callbackService).sendDestroyed(instanceId);
+        verify(callbackService, never()).sendFailed(instanceId);
+    }
 }

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePrepareServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/service/InstancePrepareServiceTest.java
@@ -1,0 +1,96 @@
+package net.spookly.kodama.nodeagent.instance.service;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import net.spookly.kodama.nodeagent.instance.callback.InstanceCallbackService;
+import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceLayer;
+import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceRequest;
+import net.spookly.kodama.nodeagent.instance.registry.InstanceRegistryService;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspaceManager;
+import net.spookly.kodama.nodeagent.instance.workspace.InstanceWorkspacePaths;
+import net.spookly.kodama.nodeagent.template.cache.TemplateCacheLookupResult;
+import net.spookly.kodama.nodeagent.template.cache.TemplateCachePopulateService;
+import net.spookly.kodama.nodeagent.template.merge.TemplateLayerMergeService;
+import org.junit.jupiter.api.Test;
+
+class InstancePrepareServiceTest {
+
+    @Test
+    void prepareDoesNotFailWhenPreparedCallbackFails() {
+        TemplateCachePopulateService cachePopulateService = mock(TemplateCachePopulateService.class);
+        TemplateLayerMergeService mergeService = mock(TemplateLayerMergeService.class);
+        InstanceWorkspaceManager workspaceManager = mock(InstanceWorkspaceManager.class);
+        InstanceVariablesResolver variablesResolver = mock(InstanceVariablesResolver.class);
+        InstanceCallbackService callbackService = mock(InstanceCallbackService.class);
+        InstanceRegistryService registryService = mock(InstanceRegistryService.class);
+        InstancePrepareService service = new InstancePrepareService(
+                cachePopulateService,
+                mergeService,
+                workspaceManager,
+                variablesResolver,
+                callbackService,
+                registryService
+        );
+
+        UUID instanceId = UUID.randomUUID();
+        UUID templateId = UUID.randomUUID();
+        UUID templateVersionId = UUID.randomUUID();
+        NodePrepareInstanceLayer layer = new NodePrepareInstanceLayer(
+                templateVersionId,
+                templateId,
+                "1.0.0",
+                "checksum",
+                "templates/test.tgz",
+                null,
+                0
+        );
+        NodePrepareInstanceRequest request = new NodePrepareInstanceRequest(
+                instanceId,
+                "demo",
+                "demo",
+                null,
+                Map.of(),
+                null,
+                List.of(layer)
+        );
+
+        InstanceWorkspacePaths workspace = new InstanceWorkspacePaths(
+                instanceId.toString(),
+                Path.of("/tmp/instances", instanceId.toString()),
+                Path.of("/tmp/instances", instanceId.toString(), "merged"),
+                Path.of("/tmp/instances", instanceId.toString(), "logs"),
+                Path.of("/tmp/instances", instanceId.toString(), "temp")
+        );
+
+        when(workspaceManager.prepareWorkspace(instanceId.toString())).thenReturn(workspace);
+        when(variablesResolver.resolve(any(), any())).thenReturn(Map.of());
+        when(cachePopulateService.ensureCachedTemplate(any(), any(), any(), any()))
+                .thenReturn(TemplateCacheLookupResult.hit(
+                        templateId.toString(),
+                        "1.0.0",
+                        "checksum",
+                        Path.of("/tmp/cache"),
+                        "checksum"
+                ));
+        doNothing().when(mergeService).mergeLayers(any(), any(), any(), any());
+        doNothing().when(registryService).recordPrepared(any(), any(), any(), any());
+        doThrow(new RuntimeException("callback boom"))
+                .when(callbackService)
+                .sendPrepared(instanceId);
+
+        assertThatNoException().isThrownBy(() -> service.prepare(request));
+
+        verify(callbackService).sendPrepared(instanceId);
+    }
+}

--- a/docs/node/operations/configuration.md
+++ b/docs/node/operations/configuration.md
@@ -15,6 +15,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - Added Docker client connection settings for local or TCP Docker Engine access.
 - Added instance runtime settings for container image and workspace mount paths.
 - Added an optional instance stop timeout for graceful shutdowns.
+- Added instance callback retry settings for Brain lifecycle callbacks.
 
 ## How to use / impact
 - Configure with environment variables or CLI args (`--node-agent.<key>=...`).
@@ -60,6 +61,8 @@ Describe the configuration inputs for the node agent and how they map to environ
   - `node-agent.instance-runtime.workspace-mount-path` (`NODE_AGENT_INSTANCE_RUNTIME_WORKSPACE_MOUNT_PATH`, default `/workspace`)
   - `node-agent.instance-runtime.working-dir` (`NODE_AGENT_INSTANCE_RUNTIME_WORKING_DIR`, defaults to workspace mount path)
   - `node-agent.instance-runtime.stop-timeout-seconds` (`NODE_AGENT_INSTANCE_RUNTIME_STOP_TIMEOUT_SECONDS`, unset uses Docker defaults)
+  - `node-agent.instance-callbacks.max-attempts` (`NODE_AGENT_INSTANCE_CALLBACKS_MAX_ATTEMPTS`, default `1`)
+  - `node-agent.instance-callbacks.retry-backoff-millis` (`NODE_AGENT_INSTANCE_CALLBACKS_RETRY_BACKOFF_MILLIS`, default `500`)
   - `node-agent.auth.header-name` (`NODE_AGENT_AUTH_HEADER_NAME`, default `X-Node-Token`)
   - `node-agent.auth.token-path` (`NODE_AGENT_AUTH_TOKEN_PATH`)
   - `node-agent.auth.cert-path` (`NODE_AGENT_AUTH_CERT_PATH`)
@@ -97,6 +100,8 @@ Describe the configuration inputs for the node agent and how they map to environ
 - `node-agent.instance-runtime.workspace-mount-path` controls where the merged workspace is mounted inside the container.
 - `node-agent.instance-runtime.working-dir` overrides the container working directory (defaults to the workspace mount path).
 - `node-agent.instance-runtime.stop-timeout-seconds` controls the graceful stop timeout before the node agent force-kills a container (unset uses Docker defaults).
+- Instance callbacks to the Brain can be retried by increasing `node-agent.instance-callbacks.max-attempts`.
+  `node-agent.instance-callbacks.retry-backoff-millis` controls the backoff between attempts.
 - S3 configuration is required for template storage. When `node-agent.s3.endpoint` is set, the client
   uses path-style requests for local or custom S3 endpoints.
 
@@ -110,6 +115,7 @@ Describe the configuration inputs for the node agent and how they map to environ
 - When `node-agent.template-cache-check.enabled=true`, missing template-id/version/checksum values
   stop the node agent at startup.
 - Invalid template cache limit values stop the node agent at startup.
+- Invalid instance callback retry values stop the node agent at startup.
 - Missing or invalid S3 settings stop the node agent when template storage is initialized.
 - Invalid Docker timeout values stop the node agent at startup.
 

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -12,6 +12,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Stop now resolves the container id from the local registry, stops the container, and records the stopped state.
 - Destroy now stops (or force-kills) the container, removes it, deletes the instance workspace, and removes the local registry entry.
 - Added a local registry listing endpoint for listing known instance records.
+- Added optional retry settings for instance callbacks to the Brain.
 
 ## How to use / impact
 - `POST /api/instances/{instanceId}/prepare` with `NodePrepareInstanceRequest`.
@@ -45,6 +46,8 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Destroy removes `instance.json` before deleting the instance workspace directory.
 - Registry entries include the instance workspace path (relative to `node-agent.workspace-dir`) and last known container status.
 - Registry listings omit `variables` to avoid leaking runtime secrets.
+- Instance callback retries are controlled by `node-agent.instance-callbacks.max-attempts` and
+  `node-agent.instance-callbacks.retry-backoff-millis`.
 - If the container is still running after the stop timeout, the node agent force-kills it.
 - The stop timeout is configured via `node-agent.instance-runtime.stop-timeout-seconds` (defaults to Docker's own timeout when unset).
 - The registry container status is updated to `stopped` after a successful stop.
@@ -54,7 +57,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 ## Edge cases / risks
 - Invalid payloads (missing instanceId, empty layers, invalid JSON) return HTTP 400 and trigger a `/failed` callback when possible.
 - Cache download/merge failures result in HTTP 500 and a `/failed` callback attempt.
-- Missing node auth token or invalid Brain base URL prevents callbacks and fails the prepare request.
+- Missing node auth token or invalid Brain base URL prevents callbacks; lifecycle commands still complete locally but the Brain will not receive updates.
 - Start requires a container image from `variables` (`DOCKER_IMAGE`, `CONTAINER_IMAGE`, or `IMAGE`) or
   `node-agent.instance-runtime.image`; missing values fail the command.
 - Start fails if the prepared workspace or `instance.json` registry record is missing.
@@ -66,7 +69,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - Destroy errors attempt a `/failed` callback before returning the error.
 - Missing `portsJson` is allowed; port bindings fall back to `PORT`/`PORT_*` variables.
 - Invalid or missing port mappings result in a failed start and a `/failed` callback attempt.
-- If the `/running` callback fails after the container starts, the node logs the error but does not send `/failed`.
+- If a success callback (`/prepared`, `/running`, `/stopped`, `/destroyed`) fails after the command completes, the node logs the error but does not send `/failed`.
 
 ## Links
 - `backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/controller/InstanceCommandController.java`


### PR DESCRIPTION
## Description
- Renamed `NodeCallbackClient` to `BrainCallbackClient` to reflect its purpose more accurately.
- Implemented retry logic with configurable attempts and backoff for instance callbacks to the Brain.
- Enhanced `InstanceCallbackService` to handle retries and improve error handling for lifecycle commands.
- Updated `NodeConfig` to include validation and properties for callback retries (`max-attempts`, `retry-backoff-millis`).
- Adjusted tests to validate callback behavior with retries and edge cases.
- Updated documentation with new configuration details and retry behavior for lifecycle callbacks.

## Linked Issues
Closes #65

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
