### PR TITLE
test(#134): add unit tests for template assignment resolution and validation

### DIFF
--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
@@ -215,6 +215,36 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceAllowsDuplicatePriorities() {
+        TemplateVersion base = createTemplateVersion("Priority Base", "1.0.0");
+        TemplateVersion overlay = createTemplateVersion("Priority Overlay", "1.0.0");
+
+        TemplateAssignmentRequest baseLayer = new TemplateAssignmentRequest(
+                base.getTemplate().getId(),
+                base.getId(),
+                0
+        );
+        TemplateAssignmentRequest overlayLayer = new TemplateAssignmentRequest(
+                overlay.getTemplate().getId(),
+                overlay.getId(),
+                0
+        );
+
+        CreateInstanceRequest request = new CreateInstanceRequest(
+                "duplicate-priority-instance",
+                List.of(baseLayer, overlayLayer)
+        );
+        request.setRequestedBy(REQUESTER_ID);
+
+        InstanceDto created = instanceService.createInstance(request);
+
+        List<InstanceTemplateAssignment> assignments =
+                instanceTemplateAssignmentRepository.findAllByInstanceId(created.getId());
+        assertThat(assignments).hasSize(2);
+        assertThat(assignments).allMatch(assignment -> assignment.getPriority() == 0);
+    }
+
+    @Test
     void createInstanceRejectsDuplicateNames() {
         TemplateVersion version = createTemplateVersion("Dupe Template", "1.0.0");
         TemplateAssignmentRequest assignment = new TemplateAssignmentRequest(

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentResolverTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentResolverTest.java
@@ -196,6 +196,29 @@ class TemplateAssignmentResolverTest {
         assertThat(resolved.get(1).source()).isEqualTo(TemplateAssignmentSource.INSTANCE);
     }
 
+    @Test
+    void resolveUsesLatestVersionWhenAssignmentOmitsVersion() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Template template = createTemplate("Latest Template", now);
+        TemplateVersion older = createTemplateVersion(template, "1.0.0", now.minusMinutes(10));
+        TemplateVersion newer = createTemplateVersion(template, "1.1.0", now);
+
+        Instance instance = createInstance("instance-latest", now);
+        instanceTemplateAssignmentRepository.save(new InstanceTemplateAssignment(
+                instance,
+                template,
+                null,
+                0
+        ));
+
+        List<ResolvedTemplateLayer> resolved = resolver.resolveForInstance(instance.getId());
+
+        assertThat(resolved).hasSize(1);
+        ResolvedTemplateLayer layer = resolved.getFirst();
+        assertThat(layer.templateVersion().getId()).isEqualTo(newer.getId());
+        assertThat(newer.getCreatedAt()).isAfter(older.getCreatedAt());
+    }
+
     private Template createTemplate(String name, OffsetDateTime now) {
         return templateRepository.save(new Template(name, "desc", TemplateType.CUSTOM, now, CREATOR_USERNAME));
     }

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentServiceTest.java
@@ -12,10 +12,12 @@ import net.spookly.kodama.brain.domain.instance.InstanceGroup;
 import net.spookly.kodama.brain.domain.instance.InstanceState;
 import net.spookly.kodama.brain.domain.template.Template;
 import net.spookly.kodama.brain.domain.template.TemplateType;
+import net.spookly.kodama.brain.domain.template.TemplateVersion;
 import net.spookly.kodama.brain.dto.TemplateAssignmentRequest;
 import net.spookly.kodama.brain.repository.InstanceGroupRepository;
 import net.spookly.kodama.brain.repository.InstanceRepository;
 import net.spookly.kodama.brain.repository.TemplateRepository;
+import net.spookly.kodama.brain.repository.TemplateVersionRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -61,6 +63,9 @@ class TemplateAssignmentServiceTest {
     @Autowired
     private TemplateRepository templateRepository;
 
+    @Autowired
+    private TemplateVersionRepository templateVersionRepository;
+
     @Test
     void addInstanceAssignmentRejectsTemplateWithoutVersions() {
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
@@ -93,6 +98,25 @@ class TemplateAssignmentServiceTest {
                 .isEqualTo(HttpStatus.NOT_FOUND);
     }
 
+    @Test
+    void addInstanceAssignmentRejectsMismatchedTemplateVersion() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Template template = createTemplate("Template A", now);
+        Template otherTemplate = createTemplate("Template B", now);
+        TemplateVersion otherVersion = createTemplateVersion(otherTemplate, "1.0.0", now);
+        Instance instance = createInstance("instance-mismatch", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest();
+        request.setTemplateId(template.getId());
+        request.setTemplateVersionId(otherVersion.getId());
+        request.setPriority(0);
+
+        assertThatThrownBy(() -> templateAssignmentService.addInstanceAssignment(instance.getId(), request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
     private Template createTemplate(String name, OffsetDateTime now) {
         return templateRepository.save(new Template(name, "desc", TemplateType.CUSTOM, now, REQUESTER_USERNAME));
     }
@@ -118,5 +142,17 @@ class TemplateAssignmentServiceTest {
     private InstanceGroup createGroup(String name, OffsetDateTime now) {
         InstanceGroup group = new InstanceGroup(name, null, now, now);
         return instanceGroupRepository.save(group);
+    }
+
+    private TemplateVersion createTemplateVersion(Template template, String version, OffsetDateTime now) {
+        TemplateVersion templateVersion = new TemplateVersion(
+                template,
+                version,
+                "checksum",
+                "s3/key",
+                null,
+                now
+        );
+        return templateVersionRepository.save(templateVersion);
     }
 }


### PR DESCRIPTION
## Description
- Added tests to ensure correct resolution of latest template version when version details are omitted.
- Added validation tests to reject mismatched template versions and templates without versions.
- Implemented tests to allow duplicate priorities in template assignments during instance creation.

## Linked Issues
Closes #134

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
