### PR TITLE
test(#137): add unit tests for template assignment deduplication and prioritization

### DIFF
--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentResolverTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentResolverTest.java
@@ -1,6 +1,7 @@
 package net.spookly.kodama.brain.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -29,8 +30,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.server.ResponseStatusException;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -217,6 +220,101 @@ class TemplateAssignmentResolverTest {
         ResolvedTemplateLayer layer = resolved.getFirst();
         assertThat(layer.templateVersion().getId()).isEqualTo(newer.getId());
         assertThat(newer.getCreatedAt()).isAfter(older.getCreatedAt());
+    }
+
+    @Test
+    void resolveDedupesGroupAssignmentsByGroupIdOnPriorityTie() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Template template = createTemplate("Group Dedup Template", now);
+        TemplateVersion version = createTemplateVersion(template, "1.0.0", now);
+
+        Instance instance = createInstance("instance-group-dedup", now);
+        InstanceGroup groupA = createGroup("group-a", now);
+        InstanceGroup groupB = createGroup("group-b", now);
+        membershipRepository.save(new InstanceGroupMembership(instance, groupA));
+        membershipRepository.save(new InstanceGroupMembership(instance, groupB));
+
+        GroupTemplateAssignment assignmentA = groupTemplateAssignmentRepository.save(new GroupTemplateAssignment(
+                groupA,
+                template,
+                version,
+                0
+        ));
+        GroupTemplateAssignment assignmentB = groupTemplateAssignmentRepository.save(new GroupTemplateAssignment(
+                groupB,
+                template,
+                version,
+                0
+        ));
+
+        GroupTemplateAssignment expected = groupA.getId().compareTo(groupB.getId()) < 0 ? assignmentA : assignmentB;
+
+        List<ResolvedTemplateLayer> resolved = resolver.resolveForInstance(instance.getId());
+
+        assertThat(resolved).hasSize(1);
+        ResolvedTemplateLayer layer = resolved.getFirst();
+        assertThat(layer.assignmentId()).isEqualTo(expected.getId());
+        assertThat(layer.source()).isEqualTo(TemplateAssignmentSource.GROUP);
+    }
+
+    @Test
+    void resolveOrdersSamePriorityByTemplateIdWithinSource() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Instance instance = createInstance("instance-template-order", now);
+
+        Template templateA = createTemplate("Template Order A", now);
+        Template templateB = createTemplate("Template Order B", now);
+        TemplateVersion versionA = createTemplateVersion(templateA, "1.0.0", now.minusMinutes(2));
+        TemplateVersion versionB = createTemplateVersion(templateB, "1.0.0", now.minusMinutes(1));
+
+        instanceTemplateAssignmentRepository.save(new InstanceTemplateAssignment(
+                instance,
+                templateA,
+                versionA,
+                1
+        ));
+        instanceTemplateAssignmentRepository.save(new InstanceTemplateAssignment(
+                instance,
+                templateB,
+                versionB,
+                1
+        ));
+
+        List<ResolvedTemplateLayer> resolved = resolver.resolveForInstance(instance.getId());
+
+        assertThat(resolved).hasSize(2);
+        UUID expectedFirst = templateA.getId().compareTo(templateB.getId()) < 0
+                ? templateA.getId()
+                : templateB.getId();
+        UUID expectedSecond = expectedFirst.equals(templateA.getId())
+                ? templateB.getId()
+                : templateA.getId();
+
+        assertThat(resolved.get(0).templateId()).isEqualTo(expectedFirst);
+        assertThat(resolved.get(1).templateId()).isEqualTo(expectedSecond);
+        assertThat(resolved.get(0).source()).isEqualTo(TemplateAssignmentSource.INSTANCE);
+        assertThat(resolved.get(1).source()).isEqualTo(TemplateAssignmentSource.INSTANCE);
+    }
+
+    @Test
+    void resolveRejectsTemplateWithoutVersionsWhenAssignmentOmitsVersion() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Template template = createTemplate("No Versions Template", now);
+        Instance instance = createInstance("instance-no-versions", now);
+
+        instanceTemplateAssignmentRepository.save(new InstanceTemplateAssignment(
+                instance,
+                template,
+                null,
+                0
+        ));
+
+        assertThatThrownBy(() -> resolver.resolveForInstance(instance.getId()))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException statusException = (ResponseStatusException) ex;
+                    assertThat(statusException.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+                });
     }
 
     private Template createTemplate(String name, OffsetDateTime now) {

--- a/docs/brain/template-assignments.md
+++ b/docs/brain/template-assignments.md
@@ -21,8 +21,8 @@ Effective layers are derived with deterministic rules:
 - When `templateVersionId` is omitted, the write path rejects templates with no versions (`404 Not Found`).
 - Conflicts by `templateId` are resolved in favor of direct instance assignments.
 - Direct instance assignments are not deduplicated; multiple layers for the same `templateId` are preserved and ordered by priority.
-- Duplicate group contributions for the same `templateId` are deduplicated by lowest `priority`, then `groupId`, then assignment id.
-- Ordering is by `priority` ascending, then source (`INSTANCE` before `GROUP`), then `templateId`, then assignment id.
+- Duplicate group contributions for the same `templateId` are deduplicated by lowest `priority`, then `groupId` (UUID natural order), then assignment id.
+- Ordering is by `priority` ascending, then source (`INSTANCE` before `GROUP`), then `templateId` (UUID natural order), then assignment id.
 - `orderIndex` is derived from the sorted list to keep node merge order deterministic.
 
 If a template has no versions at resolve time, resolution fails with `404 Not Found`.


### PR DESCRIPTION
## Description
- Added tests to validate deduplication of group assignments by `groupId` on priority ties.
- Implemented tests verifying template ordering by `templateId` within the same priority and source.
- Added test to ensure resolving templates without versions fails with 404 when version is omitted.

## Linked Issues
Closes #137

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
