### PR TITLE
feat(#152): add blueprint template assignment API with tests and documentation

### DIFF
--- a/backend/brain/README.md
+++ b/backend/brain/README.md
@@ -31,3 +31,9 @@ Validation: `name`, `type`, `s3Key`, `version`, and `checksum` must be provided.
 - `DELETE /api/instance-groups/{groupId}/template-assignments/{assignmentId}` — remove a group assignment.
 
 Validation: at least one template assignment with required `templateId`. Duplicate instance names return HTTP 409. Unknown nodes, templates, or template versions return HTTP 404. `variables` and `variablesJson` are mutually exclusive.
+
+## Blueprint API
+
+- `GET /api/blueprints/{id}/template-assignments` — list blueprint assignments.
+- `POST /api/blueprints/{id}/template-assignments` — add a blueprint assignment.
+- `DELETE /api/blueprints/{id}/template-assignments/{assignmentId}` — remove a blueprint assignment.

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/BlueprintTemplateAssignmentController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/BlueprintTemplateAssignmentController.java
@@ -1,0 +1,53 @@
+package net.spookly.kodama.brain.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+import net.spookly.kodama.brain.dto.TemplateAssignmentDto;
+import net.spookly.kodama.brain.dto.TemplateAssignmentRequest;
+import net.spookly.kodama.brain.service.TemplateAssignmentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/blueprints/{id}/template-assignments")
+public class BlueprintTemplateAssignmentController {
+
+    private final TemplateAssignmentService templateAssignmentService;
+
+    public BlueprintTemplateAssignmentController(TemplateAssignmentService templateAssignmentService) {
+        this.templateAssignmentService = templateAssignmentService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR','ROLE_VIEWER')")
+    public List<TemplateAssignmentDto> listAssignments(@PathVariable("id") UUID blueprintId) {
+        return templateAssignmentService.listBlueprintAssignments(blueprintId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    public TemplateAssignmentDto addAssignment(
+            @PathVariable("id") UUID blueprintId,
+            @Valid @RequestBody TemplateAssignmentRequest request
+    ) {
+        return templateAssignmentService.addBlueprintAssignment(blueprintId, request);
+    }
+
+    @DeleteMapping("/{assignmentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN','ROLE_OPERATOR')")
+    public void removeAssignment(@PathVariable("id") UUID blueprintId, @PathVariable UUID assignmentId) {
+        templateAssignmentService.removeBlueprintAssignment(blueprintId, assignmentId);
+    }
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/TemplateAssignmentDto.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/TemplateAssignmentDto.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.spookly.kodama.brain.domain.blueprint.BlueprintTemplateAssignment;
 import net.spookly.kodama.brain.domain.instance.GroupTemplateAssignment;
 import net.spookly.kodama.brain.domain.instance.InstanceTemplateAssignment;
 
@@ -28,6 +29,15 @@ public class TemplateAssignmentDto {
     }
 
     public static TemplateAssignmentDto fromEntity(GroupTemplateAssignment assignment) {
+        return new TemplateAssignmentDto(
+                assignment.getId(),
+                assignment.getTemplate().getId(),
+                assignment.getTemplateVersion() == null ? null : assignment.getTemplateVersion().getId(),
+                assignment.getPriority()
+        );
+    }
+
+    public static TemplateAssignmentDto fromEntity(BlueprintTemplateAssignment assignment) {
         return new TemplateAssignmentDto(
                 assignment.getId(),
                 assignment.getTemplate().getId(),

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/TemplateAssignmentService.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/TemplateAssignmentService.java
@@ -3,6 +3,8 @@ package net.spookly.kodama.brain.service;
 import java.util.List;
 import java.util.UUID;
 
+import net.spookly.kodama.brain.domain.blueprint.Blueprint;
+import net.spookly.kodama.brain.domain.blueprint.BlueprintTemplateAssignment;
 import net.spookly.kodama.brain.domain.instance.GroupTemplateAssignment;
 import net.spookly.kodama.brain.domain.instance.Instance;
 import net.spookly.kodama.brain.domain.instance.InstanceGroup;
@@ -11,6 +13,8 @@ import net.spookly.kodama.brain.domain.template.Template;
 import net.spookly.kodama.brain.domain.template.TemplateVersion;
 import net.spookly.kodama.brain.dto.TemplateAssignmentDto;
 import net.spookly.kodama.brain.dto.TemplateAssignmentRequest;
+import net.spookly.kodama.brain.repository.BlueprintRepository;
+import net.spookly.kodama.brain.repository.BlueprintTemplateAssignmentRepository;
 import net.spookly.kodama.brain.repository.GroupTemplateAssignmentRepository;
 import net.spookly.kodama.brain.repository.InstanceGroupRepository;
 import net.spookly.kodama.brain.repository.InstanceRepository;
@@ -26,27 +30,64 @@ import org.springframework.web.server.ResponseStatusException;
 @Transactional
 public class TemplateAssignmentService {
 
+    private final BlueprintTemplateAssignmentRepository blueprintTemplateAssignmentRepository;
     private final InstanceTemplateAssignmentRepository instanceTemplateAssignmentRepository;
     private final GroupTemplateAssignmentRepository groupTemplateAssignmentRepository;
+    private final BlueprintRepository blueprintRepository;
     private final InstanceRepository instanceRepository;
     private final InstanceGroupRepository instanceGroupRepository;
     private final TemplateRepository templateRepository;
     private final TemplateVersionRepository templateVersionRepository;
 
     public TemplateAssignmentService(
+            BlueprintTemplateAssignmentRepository blueprintTemplateAssignmentRepository,
             InstanceTemplateAssignmentRepository instanceTemplateAssignmentRepository,
             GroupTemplateAssignmentRepository groupTemplateAssignmentRepository,
+            BlueprintRepository blueprintRepository,
             InstanceRepository instanceRepository,
             InstanceGroupRepository instanceGroupRepository,
             TemplateRepository templateRepository,
             TemplateVersionRepository templateVersionRepository
     ) {
+        this.blueprintTemplateAssignmentRepository = blueprintTemplateAssignmentRepository;
         this.instanceTemplateAssignmentRepository = instanceTemplateAssignmentRepository;
         this.groupTemplateAssignmentRepository = groupTemplateAssignmentRepository;
+        this.blueprintRepository = blueprintRepository;
         this.instanceRepository = instanceRepository;
         this.instanceGroupRepository = instanceGroupRepository;
         this.templateRepository = templateRepository;
         this.templateVersionRepository = templateVersionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TemplateAssignmentDto> listBlueprintAssignments(UUID blueprintId) {
+        ensureBlueprintExists(blueprintId);
+        return blueprintTemplateAssignmentRepository.findAllByBlueprintId(blueprintId).stream()
+                .map(TemplateAssignmentDto::fromEntity)
+                .toList();
+    }
+
+    public TemplateAssignmentDto addBlueprintAssignment(UUID blueprintId, TemplateAssignmentRequest request) {
+        Blueprint blueprint = loadBlueprint(blueprintId);
+        AssignmentTarget target = resolveAssignmentTarget(request);
+        BlueprintTemplateAssignment assignment = new BlueprintTemplateAssignment(
+                blueprint,
+                target.template(),
+                target.templateVersion(),
+                target.priority()
+        );
+        BlueprintTemplateAssignment saved = blueprintTemplateAssignmentRepository.save(assignment);
+        return TemplateAssignmentDto.fromEntity(saved);
+    }
+
+    public void removeBlueprintAssignment(UUID blueprintId, UUID assignmentId) {
+        ensureBlueprintExists(blueprintId);
+        BlueprintTemplateAssignment assignment = blueprintTemplateAssignmentRepository.findById(assignmentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found"));
+        if (!assignment.getBlueprint().getId().equals(blueprintId)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found");
+        }
+        blueprintTemplateAssignmentRepository.delete(assignment);
     }
 
     @Transactional(readOnly = true)
@@ -146,6 +187,17 @@ public class TemplateAssignmentService {
     private void ensureInstanceExists(UUID instanceId) {
         if (!instanceRepository.existsById(instanceId)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Instance not found");
+        }
+    }
+
+    private Blueprint loadBlueprint(UUID blueprintId) {
+        return blueprintRepository.findByIdAndDeletedAtIsNull(blueprintId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Blueprint not found"));
+    }
+
+    private void ensureBlueprintExists(UUID blueprintId) {
+        if (blueprintRepository.findByIdAndDeletedAtIsNull(blueprintId).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Blueprint not found");
         }
     }
 

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/security/BlueprintTemplateAssignmentControllerTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/security/BlueprintTemplateAssignmentControllerTest.java
@@ -1,0 +1,143 @@
+package net.spookly.kodama.brain.security;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+
+import net.spookly.kodama.brain.config.BrainSecurityProperties;
+import net.spookly.kodama.brain.config.MethodSecurityConfig;
+import net.spookly.kodama.brain.config.SecurityConfig;
+import net.spookly.kodama.brain.controller.ApiExceptionHandler;
+import net.spookly.kodama.brain.controller.BlueprintTemplateAssignmentController;
+import net.spookly.kodama.brain.dto.TemplateAssignmentDto;
+import net.spookly.kodama.brain.service.TemplateAssignmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+@WebMvcTest(controllers = BlueprintTemplateAssignmentController.class)
+@EnableConfigurationProperties(BrainSecurityProperties.class)
+@Import({
+        ApiExceptionHandler.class,
+        SecurityConfig.class,
+        MethodSecurityConfig.class,
+        JwtAuthFilter.class,
+        JwtTokenService.class,
+        ConfiguredUserStore.class,
+        TestSecurityBootstrapConfig.class
+})
+@TestPropertySource(properties = "brain.security.enabled=false")
+class BlueprintTemplateAssignmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TemplateAssignmentService templateAssignmentService;
+
+    @Test
+    void listAssignmentsReturnsAssignments() throws Exception {
+        UUID blueprintId = UUID.fromString("00000000-0000-0000-0000-000000001521");
+        TemplateAssignmentDto assignment = new TemplateAssignmentDto(
+                UUID.fromString("00000000-0000-0000-0000-000000001522"),
+                UUID.fromString("00000000-0000-0000-0000-000000001523"),
+                UUID.fromString("00000000-0000-0000-0000-000000001524"),
+                0
+        );
+        given(templateAssignmentService.listBlueprintAssignments(blueprintId)).willReturn(List.of(assignment));
+
+        mockMvc.perform(get("/api/blueprints/{id}/template-assignments", blueprintId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(assignment.getId().toString()))
+                .andExpect(jsonPath("$[0].templateId").value(assignment.getTemplateId().toString()))
+                .andExpect(jsonPath("$[0].templateVersionId").value(assignment.getTemplateVersionId().toString()))
+                .andExpect(jsonPath("$[0].priority").value(0));
+    }
+
+    @Test
+    void addAssignmentReturnsCreatedStatusAndPayload() throws Exception {
+        UUID blueprintId = UUID.fromString("00000000-0000-0000-0000-000000001525");
+        UUID assignmentId = UUID.fromString("00000000-0000-0000-0000-000000001526");
+        UUID templateId = UUID.fromString("00000000-0000-0000-0000-000000001527");
+        UUID templateVersionId = UUID.fromString("00000000-0000-0000-0000-000000001528");
+        given(templateAssignmentService.addBlueprintAssignment(eq(blueprintId), any()))
+                .willReturn(new TemplateAssignmentDto(assignmentId, templateId, templateVersionId, 2));
+
+        String body = """
+                {
+                  "templateId": "%s",
+                  "templateVersionId": "%s",
+                  "priority": 2
+                }
+                """.formatted(templateId, templateVersionId);
+
+        mockMvc.perform(post("/api/blueprints/{id}/template-assignments", blueprintId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(assignmentId.toString()))
+                .andExpect(jsonPath("$.templateId").value(templateId.toString()))
+                .andExpect(jsonPath("$.templateVersionId").value(templateVersionId.toString()))
+                .andExpect(jsonPath("$.priority").value(2));
+    }
+
+    @Test
+    void removeAssignmentReturnsNoContent() throws Exception {
+        UUID blueprintId = UUID.fromString("00000000-0000-0000-0000-000000001529");
+        UUID assignmentId = UUID.fromString("00000000-0000-0000-0000-000000001530");
+
+        mockMvc.perform(delete("/api/blueprints/{id}/template-assignments/{assignmentId}", blueprintId, assignmentId))
+                .andExpect(status().isNoContent());
+
+        verify(templateAssignmentService).removeBlueprintAssignment(blueprintId, assignmentId);
+    }
+
+    @Test
+    void invalidPayloadReturnsBadRequest() throws Exception {
+        UUID blueprintId = UUID.fromString("00000000-0000-0000-0000-000000001531");
+        String body = """
+                {
+                  "priority": -1
+                }
+                """;
+
+        mockMvc.perform(post("/api/blueprints/{id}/template-assignments", blueprintId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", containsString("templateId")))
+                .andExpect(jsonPath("$.message", containsString("priority")));
+
+        verifyNoInteractions(templateAssignmentService);
+    }
+
+    @Test
+    void listAssignmentsReturnsNotFoundWhenBlueprintIsMissing() throws Exception {
+        UUID blueprintId = UUID.fromString("00000000-0000-0000-0000-000000001532");
+        given(templateAssignmentService.listBlueprintAssignments(blueprintId))
+                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Blueprint not found"));
+
+        mockMvc.perform(get("/api/blueprints/{id}/template-assignments", blueprintId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Blueprint not found"));
+    }
+}

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/TemplateAssignmentServiceTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
+import net.spookly.kodama.brain.domain.blueprint.Blueprint;
 import net.spookly.kodama.brain.domain.instance.Instance;
 import net.spookly.kodama.brain.domain.instance.InstanceGroup;
 import net.spookly.kodama.brain.domain.instance.InstanceState;
@@ -16,6 +17,7 @@ import net.spookly.kodama.brain.domain.template.TemplateType;
 import net.spookly.kodama.brain.domain.template.TemplateVersion;
 import net.spookly.kodama.brain.dto.TemplateAssignmentDto;
 import net.spookly.kodama.brain.dto.TemplateAssignmentRequest;
+import net.spookly.kodama.brain.repository.BlueprintRepository;
 import net.spookly.kodama.brain.repository.InstanceGroupRepository;
 import net.spookly.kodama.brain.repository.InstanceRepository;
 import net.spookly.kodama.brain.repository.TemplateRepository;
@@ -61,6 +63,9 @@ class TemplateAssignmentServiceTest {
 
     @Autowired
     private InstanceGroupRepository instanceGroupRepository;
+
+    @Autowired
+    private BlueprintRepository blueprintRepository;
 
     @Autowired
     private TemplateRepository templateRepository;
@@ -267,8 +272,116 @@ class TemplateAssignmentServiceTest {
                 .isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
+    @Test
+    void addBlueprintAssignmentPersistsAndListsAssignments() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Blueprint blueprint = createBlueprint("blueprint-assignments", now);
+        Template template = createTemplate("Blueprint Template", now);
+        TemplateVersion templateVersion = createTemplateVersion(template, "1.0.0", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest();
+        request.setTemplateId(template.getId());
+        request.setTemplateVersionId(templateVersion.getId());
+        request.setPriority(4);
+
+        TemplateAssignmentDto created = templateAssignmentService.addBlueprintAssignment(blueprint.getId(), request);
+
+        assertThat(created.getId()).isNotNull();
+        assertThat(created.getTemplateId()).isEqualTo(template.getId());
+        assertThat(created.getTemplateVersionId()).isEqualTo(templateVersion.getId());
+        assertThat(created.getPriority()).isEqualTo(4);
+
+        List<TemplateAssignmentDto> assignments = templateAssignmentService.listBlueprintAssignments(blueprint.getId());
+        assertThat(assignments).hasSize(1);
+        assertThat(assignments.getFirst().getId()).isEqualTo(created.getId());
+    }
+
+    @Test
+    void removeBlueprintAssignmentDeletesAssignment() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Blueprint blueprint = createBlueprint("blueprint-remove", now);
+        Template template = createTemplate("Blueprint Template Remove", now);
+        TemplateVersion templateVersion = createTemplateVersion(template, "1.0.0", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest(
+                template.getId(),
+                templateVersion.getId(),
+                1
+        );
+        TemplateAssignmentDto created = templateAssignmentService.addBlueprintAssignment(blueprint.getId(), request);
+
+        templateAssignmentService.removeBlueprintAssignment(blueprint.getId(), created.getId());
+
+        assertThat(templateAssignmentService.listBlueprintAssignments(blueprint.getId())).isEmpty();
+    }
+
+    @Test
+    void addBlueprintAssignmentRejectsMissingTemplateVersion() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Blueprint blueprint = createBlueprint("blueprint-missing-version", now);
+        Template template = createTemplate("Blueprint Template Missing Version", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest();
+        request.setTemplateId(template.getId());
+        request.setTemplateVersionId(UUID.fromString("00000000-0000-0000-0000-000000000912"));
+        request.setPriority(0);
+
+        assertThatThrownBy(() -> templateAssignmentService.addBlueprintAssignment(blueprint.getId(), request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void addBlueprintAssignmentRejectsMissingTemplate() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Blueprint blueprint = createBlueprint("blueprint-missing-template", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest();
+        request.setTemplateId(UUID.fromString("00000000-0000-0000-0000-000000000913"));
+        request.setPriority(0);
+
+        assertThatThrownBy(() -> templateAssignmentService.addBlueprintAssignment(blueprint.getId(), request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void addBlueprintAssignmentRejectsMismatchedTemplateVersion() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Blueprint blueprint = createBlueprint("blueprint-mismatch", now);
+        Template template = createTemplate("Blueprint Template A", now);
+        Template otherTemplate = createTemplate("Blueprint Template B", now);
+        TemplateVersion otherVersion = createTemplateVersion(otherTemplate, "1.0.0", now);
+
+        TemplateAssignmentRequest request = new TemplateAssignmentRequest();
+        request.setTemplateId(template.getId());
+        request.setTemplateVersionId(otherVersion.getId());
+        request.setPriority(0);
+
+        assertThatThrownBy(() -> templateAssignmentService.addBlueprintAssignment(blueprint.getId(), request))
+                .isInstanceOf(ResponseStatusException.class)
+                .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
     private Template createTemplate(String name, OffsetDateTime now) {
         return templateRepository.save(new Template(name, "desc", TemplateType.CUSTOM, now, REQUESTER_USERNAME));
+    }
+
+    private Blueprint createBlueprint(String name, OffsetDateTime now) {
+        return blueprintRepository.save(new Blueprint(
+                name,
+                false,
+                1,
+                "ghcr.io/spookly/hytale:latest",
+                null,
+                "[\"./run.sh\"]",
+                null,
+                now,
+                now
+        ));
     }
 
     private Instance createInstance(String name, OffsetDateTime now) {

--- a/docs/brain/blueprints.md
+++ b/docs/brain/blueprints.md
@@ -11,6 +11,10 @@ Define the canonical blueprint data model and Brain ↔ Node payload shapes for 
   - `GET /api/blueprints/{id}`
   - `PUT /api/blueprints/{id}`
   - `DELETE /api/blueprints/{id}` (soft delete via `deletedAt`)
+- Implemented blueprint template assignment endpoints:
+  - `GET /api/blueprints/{id}/template-assignments`
+  - `POST /api/blueprints/{id}/template-assignments`
+  - `DELETE /api/blueprints/{id}/template-assignments/{assignmentId}`
 - Added request validation for blueprint CRUD:
   - required: `name`, `containerImage`, `startCommand`
   - optional: `installScript`, `variablesJson`

--- a/docs/brain/template-assignments.md
+++ b/docs/brain/template-assignments.md
@@ -1,11 +1,12 @@
 # Template Assignments
 
 ## Purpose
-Template assignments replace the legacy `instance_template_layers` table and allow templates to be attached directly to instances and to groups. Effective template layers are resolved by merging instance and group assignments.
+Template assignments replace the legacy `instance_template_layers` table and allow templates to be attached directly to instances, groups, and blueprints. Effective template layers are resolved by merging instance and group assignments.
 
 ## Data Model
 - `instance_template_assignments` (direct instance assignments)
 - `group_template_assignments` (group assignments)
+- `blueprint_template_assignments` (blueprint defaults for instance creation)
 
 Fields:
 - `template_id` (required)
@@ -72,6 +73,9 @@ Final order (with `orderIndex`) uses priority, source, then `templateId` orderin
 - `GET /api/instance-groups/{groupId}/template-assignments` — list group assignments.
 - `POST /api/instance-groups/{groupId}/template-assignments` — add group assignment.
 - `DELETE /api/instance-groups/{groupId}/template-assignments/{assignmentId}` — remove group assignment.
+- `GET /api/blueprints/{id}/template-assignments` — list blueprint assignments.
+- `POST /api/blueprints/{id}/template-assignments` — add blueprint assignment.
+- `DELETE /api/blueprints/{id}/template-assignments/{assignmentId}` — remove blueprint assignment.
 
 ## Migration Notes
 Flyway migration `V12__create_instance_group_and_assignment_tables.sql` backfills legacy `instance_template_layers` into `instance_template_assignments` with `priority = order_index`.


### PR DESCRIPTION
## Description
- Introduced `BlueprintTemplateAssignmentController` to manage template assignments for blueprints.
- Added endpoints: `GET`, `POST`, and `DELETE` for blueprint template assignments with role-based access control.
- Implemented service methods for listing, adding, and removing blueprint template assignments.
- Added validation and exception handling for assignment operations.
- Updated documentation to reflect new endpoints and their purpose.
- Included tests for controller, service logic, and invalid input cases.

## Linked Issues
Closes #152

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
