### PR TITLE
feat(#156): add support for port definitions in instance preparation

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/controller/NodeCallbackController.java
@@ -2,11 +2,13 @@ package net.spookly.kodama.brain.controller;
 
 import java.util.UUID;
 
+import net.spookly.kodama.brain.dto.node.InstancePreparedCallbackRequest;
 import net.spookly.kodama.brain.service.InstanceService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,8 +26,16 @@ public class NodeCallbackController {
     @PostMapping("/prepared")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("hasAuthority('ROLE_NODE')")
-    public void prepared(@PathVariable UUID nodeId, @PathVariable UUID instanceId) {
-        instanceService.reportInstancePrepared(nodeId, instanceId);
+    public void prepared(
+            @PathVariable UUID nodeId,
+            @PathVariable UUID instanceId,
+            @RequestBody(required = false) InstancePreparedCallbackRequest request
+    ) {
+        instanceService.reportInstancePrepared(
+                nodeId,
+                instanceId,
+                request == null ? null : request.getPortsJson()
+        );
     }
 
     @PostMapping("/running")

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/domain/instance/Instance.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/domain/instance/Instance.java
@@ -161,6 +161,10 @@ public class Instance {
         this.portDefinitionsJson = portDefinitionsJson;
     }
 
+    public void updatePortsJson(String portsJson) {
+        this.portsJson = portsJson;
+    }
+
     public void markPrepared(OffsetDateTime timestamp) {
         updateLifecycle(InstanceState.PREPARED, timestamp);
         this.failureReason = null;

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/node/InstancePreparedCallbackRequest.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/node/InstancePreparedCallbackRequest.java
@@ -1,0 +1,13 @@
+package net.spookly.kodama.brain.dto.node;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InstancePreparedCallbackRequest {
+
+    private String portsJson;
+}

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/node/NodePrepareInstanceRequest.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/node/NodePrepareInstanceRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import net.spookly.kodama.brain.dto.PortDefinitionRequest;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,11 @@ public class NodePrepareInstanceRequest {
     private UUID instanceId;
     private String name;
     private String displayName;
+    private String containerImage;
+    private String installScript;
+    private List<String> startCommand;
+    private Integer slotsRequired;
+    private List<PortDefinitionRequest> portDefinitions;
     private String portsJson;
     private Map<String, String> variables;
     private String variablesJson;

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/CommandDispatcherService.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/CommandDispatcherService.java
@@ -6,11 +6,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import net.spookly.kodama.brain.config.BrainSecurityProperties;
 import net.spookly.kodama.brain.config.NodeProperties;
 import net.spookly.kodama.brain.domain.instance.Instance;
 import net.spookly.kodama.brain.domain.node.Node;
 import net.spookly.kodama.brain.domain.template.TemplateVersion;
+import net.spookly.kodama.brain.dto.PortDefinitionRequest;
 import net.spookly.kodama.brain.dto.node.NodeInstanceCommandRequest;
 import net.spookly.kodama.brain.dto.node.NodePrepareInstanceLayer;
 import net.spookly.kodama.brain.dto.node.NodePrepareInstanceRequest;
@@ -39,17 +43,20 @@ public class CommandDispatcherService {
     private final NodeProperties nodeProperties;
     private final BrainPluginRegistry pluginRegistry;
     private final BrainSecurityProperties securityProperties;
+    private final ObjectMapper objectMapper;
 
     public CommandDispatcherService(
             RestTemplate restTemplate,
             NodeProperties nodeProperties,
             BrainPluginRegistry pluginRegistry,
-            BrainSecurityProperties brainSecurityProperties
+            BrainSecurityProperties brainSecurityProperties,
+            ObjectMapper objectMapper
     ) {
         this.restTemplate = restTemplate;
         this.nodeProperties = nodeProperties;
         this.securityProperties = brainSecurityProperties;
         this.pluginRegistry = Objects.requireNonNull(pluginRegistry, "pluginRegistry");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
     }
 
     public void sendPrepareInstance(
@@ -82,6 +89,11 @@ public class CommandDispatcherService {
                 instanceId,
                 instance.getName(),
                 instance.getDisplayName(),
+                instance.getContainerImage(),
+                instance.getInstallScript(),
+                resolveStartCommand(instance),
+                instance.getSlotsRequired(),
+                resolvePortDefinitions(instance),
                 instance.getPortsJson(),
                 resolved.variables(),
                 resolved.variablesJson(),
@@ -220,5 +232,31 @@ public class CommandDispatcherService {
             throw new IllegalStateException("Instance id is required to dispatch node commands");
         }
         return id;
+    }
+
+    private List<String> resolveStartCommand(Instance instance) {
+        String startCommandJson = instance.getStartCommandJson();
+        if (startCommandJson == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(startCommandJson, new TypeReference<List<String>>() {
+            });
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Instance startCommandJson is invalid JSON", ex);
+        }
+    }
+
+    private List<PortDefinitionRequest> resolvePortDefinitions(Instance instance) {
+        String portDefinitionsJson = instance.getPortDefinitionsJson();
+        if (portDefinitionsJson == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(portDefinitionsJson, new TypeReference<List<PortDefinitionRequest>>() {
+            });
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Instance portDefinitionsJson is invalid JSON", ex);
+        }
     }
 }

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceService.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceService.java
@@ -243,7 +243,14 @@ public class InstanceService {
     }
 
     public void reportInstancePrepared(UUID nodeId, UUID instanceId) {
+        reportInstancePrepared(nodeId, instanceId, null);
+    }
+
+    public void reportInstancePrepared(UUID nodeId, UUID instanceId, String portsJson) {
         Instance instance = loadInstanceForNode(nodeId, instanceId);
+        if (portsJson != null) {
+            instance.updatePortsJson(portsJson);
+        }
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         if (instance.getState() == InstanceState.REQUESTED) {
             OffsetDateTime dispatchedAt = now.minusNanos(1_000);

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthIntegrationTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/security/NodeAuthIntegrationTest.java
@@ -1,6 +1,7 @@
 package net.spookly.kodama.brain.security;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -181,5 +182,29 @@ class NodeAuthIntegrationTest {
                         + "/00000000-0000-0000-0000-000000000002/prepared")
                         .header(NODE_TOKEN_HEADER, NODE_TOKEN_VALUE))
                 .andExpect(status().isOk());
+
+        verify(instanceService).reportInstancePrepared(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                null
+        );
+    }
+
+    @Test
+    void preparedCallbackWithPortsJsonIsOk() throws Exception {
+        String body = "{\"portsJson\":\"{\\\"game\\\":25565}\"}";
+
+        mockMvc.perform(post("/api/nodes/00000000-0000-0000-0000-000000000001/instances"
+                        + "/00000000-0000-0000-0000-000000000002/prepared")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body)
+                        .header(NODE_TOKEN_HEADER, NODE_TOKEN_VALUE))
+                .andExpect(status().isOk());
+
+        verify(instanceService).reportInstancePrepared(
+                UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                "{\"game\":25565}"
+        );
     }
 }

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/CommandDispatcherServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/CommandDispatcherServiceTest.java
@@ -25,6 +25,7 @@ import net.spookly.kodama.brain.domain.node.NodeStatus;
 import net.spookly.kodama.brain.domain.template.Template;
 import net.spookly.kodama.brain.domain.template.TemplateType;
 import net.spookly.kodama.brain.domain.template.TemplateVersion;
+import net.spookly.kodama.brain.dto.PortDefinitionRequest;
 import net.spookly.kodama.brain.dto.node.NodeInstanceCommandRequest;
 import net.spookly.kodama.brain.dto.node.NodePrepareInstanceLayer;
 import net.spookly.kodama.brain.dto.node.NodePrepareInstanceRequest;
@@ -56,7 +57,7 @@ class CommandDispatcherServiceTest {
         PluginsProperties pluginsProperties = new PluginsProperties();
         BrainSecurityProperties securityProperties = new BrainSecurityProperties();
         BrainPluginRegistry registry = new BrainPluginRegistry(pluginsProperties, objectMapper);
-        dispatcher = new CommandDispatcherService(restTemplate, nodeProperties, registry, securityProperties);
+        dispatcher = new CommandDispatcherService(restTemplate, nodeProperties, registry, securityProperties, objectMapper);
     }
 
     @Test
@@ -83,6 +84,16 @@ class CommandDispatcherServiceTest {
                 instanceId,
                 instance.getName(),
                 instance.getDisplayName(),
+                "ghcr.io/spookly/hytale:latest",
+                "echo install",
+                List.of("./start.sh", "--port", "25565"),
+                2,
+                List.of(new PortDefinitionRequest(
+                        "game",
+                        "tcp",
+                        25565,
+                        new PortDefinitionRequest.HostRangeRequest(25565, 25565, 1)
+                )),
                 instance.getPortsJson(),
                 variables,
                 null,
@@ -213,6 +224,16 @@ class CommandDispatcherServiceTest {
                 now
         );
         ReflectionTestUtils.setField(instance, "id", instanceId);
+        instance.applyBlueprintAndRuntime(
+                null,
+                null,
+                2,
+                "ghcr.io/spookly/hytale:latest",
+                "echo install",
+                "[\"./start.sh\",\"--port\",\"25565\"]",
+                "[{\"name\":\"game\",\"protocol\":\"tcp\",\"containerPort\":25565,"
+                        + "\"hostRange\":{\"min\":25565,\"max\":25565,\"step\":1}}]"
+        );
         return instance;
     }
 

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
@@ -153,7 +153,8 @@ class InstanceServiceTest {
                     new RestTemplate(),
                     new NodeProperties(),
                     new BrainPluginRegistry(new PluginsProperties(), objectMapper),
-                    new BrainSecurityProperties()
+                    new BrainSecurityProperties(),
+                    objectMapper
             );
         }
     }
@@ -767,6 +768,43 @@ class InstanceServiceTest {
                 instanceEventRepository.findAllByInstanceIdOrderByTimestampAsc(instance.getId());
         assertThat(events).isNotEmpty();
         assertThat(events.getLast().getType()).isEqualTo(InstanceEventType.PREPARE_COMPLETED);
+    }
+
+    @Test
+    void reportPreparedPersistsPortsJsonWhenProvided() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        Node node = nodeRepository.save(new Node(
+                "node-callback-ports",
+                "eu-west-1",
+                NodeStatus.ONLINE,
+                false,
+                4,
+                1,
+                now,
+                "1.0.0",
+                null,
+                "http://node.local"
+        ));
+        Instance instance = instanceRepository.save(new Instance(
+                "instance-callback-ports",
+                "Callback Ports Instance",
+                InstanceState.PREPARING,
+                REQUESTER_ID,
+                node,
+                null,
+                null,
+                null,
+                "{\"old\":25565}",
+                null,
+                now,
+                now
+        ));
+
+        instanceService.reportInstancePrepared(node.getId(), instance.getId(), "{\"game\":30000}");
+
+        Instance persisted = instanceRepository.findById(instance.getId()).orElseThrow();
+        assertThat(persisted.getState()).isEqualTo(InstanceState.STARTING);
+        assertThat(persisted.getPortsJson()).isEqualTo("{\"game\":30000}");
     }
 
     @Test

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodePrepareInstanceRequest.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodePrepareInstanceRequest.java
@@ -8,9 +8,38 @@ public record NodePrepareInstanceRequest(
         UUID instanceId,
         String name,
         String displayName,
+        String containerImage,
+        String installScript,
+        List<String> startCommand,
+        Integer slotsRequired,
+        List<NodePreparePortDefinition> portDefinitions,
         String portsJson,
         Map<String, String> variables,
         String variablesJson,
         List<NodePrepareInstanceLayer> layers
 ) {
+    public NodePrepareInstanceRequest(
+            UUID instanceId,
+            String name,
+            String displayName,
+            String portsJson,
+            Map<String, String> variables,
+            String variablesJson,
+            List<NodePrepareInstanceLayer> layers
+    ) {
+        this(
+                instanceId,
+                name,
+                displayName,
+                null,
+                null,
+                null,
+                null,
+                null,
+                portsJson,
+                variables,
+                variablesJson,
+                layers
+        );
+    }
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodePreparePortDefinition.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/dto/NodePreparePortDefinition.java
@@ -1,0 +1,15 @@
+package net.spookly.kodama.nodeagent.instance.dto;
+
+public record NodePreparePortDefinition(
+        String name,
+        String protocol,
+        Integer containerPort,
+        HostRange hostRange
+) {
+    public record HostRange(
+            Integer min,
+            Integer max,
+            Integer step
+    ) {
+    }
+}

--- a/contracts/nodeapi.yml
+++ b/contracts/nodeapi.yml
@@ -66,8 +66,9 @@ endpoints:
       containerImage: string|null
       installScript: string|null
       startCommand: list<string>|null
+      slotsRequired: int32|null
       portsJson: string|null
-      ports:
+      portDefinitions:
         - name: string
           protocol: tcp|udp
           containerPort: int32

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -833,7 +833,7 @@ paths:
       security:
         - nodeToken: []
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
@@ -1310,13 +1310,11 @@ components:
           minimum: 0
     InstancePreparedCallbackRequest:
       type: object
-      required: [portsJson]
       properties:
         portsJson:
           type: string
           nullable: true
-          description: Legacy port mapping JSON; prefer portDefinitions with blueprints.
-          description: Serialized JSON array of allocated ports.
+          description: Serialized JSON with allocated ports reported by the node; optional.
     NodeRegistrationResponse:
       type: object
       required: [nodeId, heartbeatIntervalSeconds]

--- a/docs/brain/node-callback-endpoints.md
+++ b/docs/brain/node-callback-endpoints.md
@@ -7,6 +7,8 @@ Base path: `/api/nodes/{nodeId}/instances/{instanceId}`
 ## Endpoints
 
 - `POST /prepared`
+  - Optional body: `{ "portsJson": "..." }`.
+  - When `portsJson` is provided, Brain persists it on the instance.
   - Updates instance state to `STARTING`.
   - If the instance is still `REQUESTED`, the Brain records `PREPARE_DISPATCHED` then transitions `REQUESTED` → `PREPARING` → `STARTING`.
   - Logs `PREPARE_COMPLETED` event.

--- a/docs/brain/node-command-dispatcher.md
+++ b/docs/brain/node-command-dispatcher.md
@@ -19,6 +19,22 @@ Body: `NodePrepareInstanceRequest`
   "instanceId": "uuid",
   "name": "string",
   "displayName": "string",
+  "containerImage": "string|null",
+  "installScript": "string|null",
+  "startCommand": ["./start.sh", "--flag"],
+  "slotsRequired": 1,
+  "portDefinitions": [
+    {
+      "name": "game",
+      "protocol": "tcp",
+      "containerPort": 25565,
+      "hostRange": {
+        "min": 30000,
+        "max": 30100,
+        "step": 1
+      }
+    }
+  ],
   "portsJson": "string|null",
   "variables": {
     "KEY": "VALUE"
@@ -39,6 +55,7 @@ Body: `NodePrepareInstanceRequest`
 ```
 
 `variables` and `variablesJson` are mutually exclusive. Brain will send `variables` when provided, otherwise it forwards `variablesJson` from the instance record. `orderIndex` is derived from template assignment priority and deterministic tie-breakers.
+`containerImage`, `installScript`, `startCommand`, `slotsRequired`, and `portDefinitions` are resolved from blueprint/runtime overrides before dispatch.
 
 ### Start
 

--- a/docs/node/operations/instance-commands.md
+++ b/docs/node/operations/instance-commands.md
@@ -23,7 +23,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
   - merges layers into the instance `merged` workspace,
   - applies variable substitution,
   - writes `instance.json` metadata into the instance workspace,
-  - calls back to the Brain with `/api/nodes/{nodeId}/instances/{instanceId}/prepared` (includes the node auth header when configured).
+  - calls back to the Brain with `/api/nodes/{nodeId}/instances/{instanceId}/prepared` (includes the node auth header when configured, and may include `portsJson` when allocated ports are known).
 - `POST /api/instances/{instanceId}/start` with `NodeInstanceCommandRequest`.
 - `POST /api/instances/{instanceId}/stop` with `NodeInstanceCommandRequest`.
 - `POST /api/instances/{instanceId}/destroy` with `NodeInstanceCommandRequest`.
@@ -55,6 +55,7 @@ Describe the node agent endpoints that handle instance lifecycle commands from t
 - The registry container status is updated to `stopped` after a successful stop.
 - `variables` and `variablesJson` are mutually exclusive. When `variablesJson` is provided, the node agent parses it as a JSON map.
 - Template cache lookups use `templateId` from the prepare payload as the cache key.
+- Prepare payload includes resolved runtime fields from Brain: `containerImage`, `installScript`, `startCommand`, `slotsRequired`, and `portDefinitions`.
 
 ## Edge cases / risks
 - Invalid payloads (missing instanceId, empty layers, invalid JSON) return HTTP 400 and trigger a `/failed` callback when possible.


### PR DESCRIPTION
## Description
- Extended instance preparation service to include `containerImage`, `installScript`, `startCommand`, `slotsRequired`, and `portDefinitions`.
- Updated DTOs to support new fields for detailed runtime configuration.
- Enhanced `NodeCallbackController` to handle optional `portsJson` in the `/prepared` callback.
- Improved JSON deserialization for `startCommand` and `portDefinitions` using `ObjectMapper`.
- Updated OpenAPI contracts and documentation to reflect changes.

## Linked Issues
Closes #156

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
