### PR TITLE
feat(#157): enforce node capacity checks for `slotsRequired` during instance creation

### DIFF
--- a/backend/brain/src/main/java/net/spookly/kodama/brain/dto/InstanceDto.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/dto/InstanceDto.java
@@ -26,6 +26,7 @@ public class InstanceDto {
     private String region;
     private String tags;
     private Boolean devModeAllowed;
+    private Integer slotsRequired;
     private String portsJson;
     private String variablesJson;
     private OffsetDateTime createdAt;
@@ -51,6 +52,7 @@ public class InstanceDto {
                 instance.getRegion(),
                 instance.getTags(),
                 instance.getDevModeAllowed(),
+                instance.getSlotsRequired(),
                 instance.getPortsJson(),
                 instance.getVariablesJson(),
                 instance.getCreatedAt(),

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceService.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/InstanceService.java
@@ -104,14 +104,32 @@ public class InstanceService {
 
         InstanceCreationPreparationService.PreparedCreateInstanceRequest preparedCreateRequest =
                 instanceCreationPreparationService.prepareForCreate(request);
+        InstanceCreationPreparationService.RuntimeConfiguration runtimeConfiguration =
+                preparedCreateRequest.runtimeConfiguration();
 
         Node node;
         if (request.getNodeId() != null) {
             node = nodeRepository.findById(request.getNodeId())
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Node not found"));
+            validateNodeCapacity(node, runtimeConfiguration.slotsRequired());
         } else {
-            node = schedulingService.selectNode(request.getRegion(), request.getTags(), request.getDevModeAllowed());
+            node = schedulingService.selectNode(
+                    request.getRegion(),
+                    request.getTags(),
+                    request.getDevModeAllowed(),
+                    runtimeConfiguration.slotsRequired()
+            );
             if (node == null) {
+                if (schedulingService.hasEligibleNodes(
+                        request.getRegion(),
+                        request.getTags(),
+                        request.getDevModeAllowed()
+                )) {
+                    throw new ResponseStatusException(
+                            HttpStatus.CONFLICT,
+                            "Insufficient node capacity for slotsRequired=" + runtimeConfiguration.slotsRequired()
+                    );
+                }
                 throw new ResponseStatusException(HttpStatus.CONFLICT, "No eligible nodes found");
             }
         }
@@ -131,8 +149,6 @@ public class InstanceService {
                 now,
                 now
         );
-        InstanceCreationPreparationService.RuntimeConfiguration runtimeConfiguration =
-                preparedCreateRequest.runtimeConfiguration();
         instance.applyBlueprintAndRuntime(
                 preparedCreateRequest.blueprint(),
                 runtimeConfiguration.permanent(),
@@ -287,6 +303,21 @@ public class InstanceService {
         Instance instance = loadInstanceForNode(nodeId, instanceId);
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         instanceStateMachine.transition(instance, InstanceState.FAILED, InstanceEventType.FAILURE_REPORTED, now, null);
+    }
+
+    private void validateNodeCapacity(Node node, int slotsRequired) {
+        if (((long) node.getUsedSlots() + slotsRequired) > node.getCapacitySlots()) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Insufficient node capacity for slotsRequired="
+                            + slotsRequired
+                            + " (usedSlots="
+                            + node.getUsedSlots()
+                            + ", capacitySlots="
+                            + node.getCapacitySlots()
+                            + ")"
+            );
+        }
     }
 
     private Instance loadInstanceForNode(UUID nodeId, UUID instanceId) {

--- a/backend/brain/src/main/java/net/spookly/kodama/brain/service/SchedulingService.java
+++ b/backend/brain/src/main/java/net/spookly/kodama/brain/service/SchedulingService.java
@@ -36,19 +36,22 @@ public class SchedulingService {
         if (instance == null) {
             throw new IllegalArgumentException("instance");
         }
+        int slotsRequired = normalizeSlotsRequired(instance.getSlotsRequired());
         Node node = selectNodeFromCandidates(
                 nodeRepository.findAll(),
                 instance.getRegion(),
                 instance.getTags(),
-                instance.getDevModeAllowed()
+                instance.getDevModeAllowed(),
+                slotsRequired
         );
         if (node == null) {
             logger.warn(
-                    "No eligible nodes found for instance {} (region={}, tags={}, devModeAllowed={})",
+                    "No eligible nodes found for instance {} (region={}, tags={}, devModeAllowed={}, slotsRequired={})",
                     instance.getId(),
                     instance.getRegion(),
                     instance.getTags(),
-                    instance.getDevModeAllowed()
+                    instance.getDevModeAllowed(),
+                    slotsRequired
             );
         }
         return node;
@@ -56,31 +59,70 @@ public class SchedulingService {
 
     @Transactional(readOnly = true)
     public Node selectNode(String region, String tags, Boolean devModeAllowed) {
-        return selectNodeFromCandidates(nodeRepository.findAll(), region, tags, devModeAllowed);
+        return selectNode(region, tags, devModeAllowed, 1);
+    }
+
+    @Transactional(readOnly = true)
+    public Node selectNode(String region, String tags, Boolean devModeAllowed, int slotsRequired) {
+        return selectNodeFromCandidates(nodeRepository.findAll(), region, tags, devModeAllowed, slotsRequired);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasEligibleNodes(String region, String tags, Boolean devModeAllowed) {
+        return hasEligibleNodesFromCandidates(nodeRepository.findAll(), region, tags, devModeAllowed);
     }
 
     Node selectNodeFromCandidates(
             Collection<Node> nodes,
             String region,
             String tags,
-            Boolean devModeAllowed
+            Boolean devModeAllowed,
+            int slotsRequired
     ) {
         if (nodes == null || nodes.isEmpty()) {
             return null;
         }
 
+        int normalizedSlotsRequired = normalizeSlotsRequired(slotsRequired);
         String normalizedRegion = normalizeRegion(region);
         Set<String> requestedTags = parseTags(tags);
 
         return nodes.stream()
-                .filter(node -> node.getStatus() == NodeStatus.ONLINE)
-                .filter(node -> normalizedRegion == null || normalizedRegion.equals(node.getRegion()))
-                .filter(node -> devModeAllowed == null || node.isDevMode() == devModeAllowed)
-                .filter(node -> node.getUsedSlots() < node.getCapacitySlots())
-                .filter(node -> hasRequiredTags(node, requestedTags))
+                .filter(node -> matchesFilters(node, normalizedRegion, requestedTags, devModeAllowed))
+                .filter(node -> hasCapacity(node, normalizedSlotsRequired))
                 .sorted(NODE_ORDERING)
                 .findFirst()
                 .orElse(null);
+    }
+
+    boolean hasEligibleNodesFromCandidates(
+            Collection<Node> nodes,
+            String region,
+            String tags,
+            Boolean devModeAllowed
+    ) {
+        if (nodes == null || nodes.isEmpty()) {
+            return false;
+        }
+        String normalizedRegion = normalizeRegion(region);
+        Set<String> requestedTags = parseTags(tags);
+        return nodes.stream().anyMatch(node -> matchesFilters(node, normalizedRegion, requestedTags, devModeAllowed));
+    }
+
+    private boolean matchesFilters(
+            Node node,
+            String normalizedRegion,
+            Set<String> requestedTags,
+            Boolean devModeAllowed
+    ) {
+        return node.getStatus() == NodeStatus.ONLINE
+                && (normalizedRegion == null || normalizedRegion.equals(node.getRegion()))
+                && (devModeAllowed == null || node.isDevMode() == devModeAllowed)
+                && hasRequiredTags(node, requestedTags);
+    }
+
+    private boolean hasCapacity(Node node, int slotsRequired) {
+        return ((long) node.getUsedSlots() + slotsRequired) <= node.getCapacitySlots();
     }
 
     private boolean hasRequiredTags(Node node, Set<String> requestedTags) {
@@ -109,5 +151,15 @@ public class SchedulingService {
                 .filter(tag -> !tag.isEmpty())
                 .map(tag -> tag.toLowerCase(Locale.ROOT))
                 .collect(Collectors.toSet());
+    }
+
+    private int normalizeSlotsRequired(Integer slotsRequired) {
+        if (slotsRequired == null) {
+            return 1;
+        }
+        if (slotsRequired < 1) {
+            throw new IllegalArgumentException("slotsRequired must be at least 1");
+        }
+        return slotsRequired;
     }
 }

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/InstanceServiceTest.java
@@ -196,6 +196,8 @@ class InstanceServiceTest {
         assertThat(persisted.getRegion()).isEqualTo("eu-west-1");
         assertThat(persisted.getTags()).isEqualTo("primary,ssd");
         assertThat(persisted.getDevModeAllowed()).isTrue();
+        assertThat(persisted.getSlotsRequired()).isEqualTo(1);
+        assertThat(created.getSlotsRequired()).isEqualTo(1);
 
         List<InstanceTemplateAssignment> assignments =
                 instanceTemplateAssignmentRepository.findAllByInstanceId(created.getId());
@@ -404,6 +406,42 @@ class InstanceServiceTest {
     }
 
     @Test
+    void createInstanceRejectsProvidedNodeWhenCapacityInsufficient() {
+        Node node = nodeRepository.save(new Node(
+                "node-tight-capacity",
+                "eu-west",
+                NodeStatus.ONLINE,
+                false,
+                3,
+                2,
+                OffsetDateTime.now(ZoneOffset.UTC),
+                "1.0.0",
+                null,
+                "http://node-tight-capacity.internal"
+        ));
+        TemplateVersion version = createTemplateVersion("Tight Node Template", "1.0.0");
+
+        CreateInstanceRequest request = new CreateInstanceRequest(
+                "with-tight-node",
+                List.of(new TemplateAssignmentRequest(
+                        version.getTemplate().getId(),
+                        version.getId(),
+                        0
+                ))
+        );
+        request.setNodeId(node.getId());
+        request.setSlotsRequired(2);
+
+        assertThatThrownBy(() -> instanceService.createInstance(request))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException statusException = (ResponseStatusException) ex;
+                    assertThat(statusException.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(statusException.getReason()).contains("Insufficient node capacity");
+                });
+    }
+
+    @Test
     void createInstanceSelectsNodeWhenNodeIdMissing() {
         Node selectedNode = createOnlineNode(
                 "node-low",
@@ -460,6 +498,48 @@ class InstanceServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
                 .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void createInstanceRejectsWhenFilteredNodesHaveInsufficientCapacityForSlotsRequired() {
+        createOnlineNode(
+                "node-nearly-full",
+                "eu-west-1",
+                false,
+                "primary,ssd",
+                4,
+                3
+        );
+        createOnlineNode(
+                "node-also-nearly-full",
+                "eu-west-1",
+                false,
+                "primary,ssd",
+                6,
+                5
+        );
+        TemplateVersion version = createTemplateVersion("Capacity Template", "1.0.0");
+
+        CreateInstanceRequest request = new CreateInstanceRequest(
+                "capacity-too-small",
+                List.of(new TemplateAssignmentRequest(
+                        version.getTemplate().getId(),
+                        version.getId(),
+                        0
+                ))
+        );
+        request.setRegion("eu-west-1");
+        request.setTags("primary,ssd");
+        request.setDevModeAllowed(Boolean.FALSE);
+        request.setSlotsRequired(2);
+
+        assertThatThrownBy(() -> instanceService.createInstance(request))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> {
+                    ResponseStatusException statusException = (ResponseStatusException) ex;
+                    assertThat(statusException.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                    assertThat(statusException.getReason()).isEqualTo("Insufficient node capacity for slotsRequired=2");
+                });
     }
 
     @Test
@@ -634,6 +714,7 @@ class InstanceServiceTest {
         assertThat(persisted.getBlueprint().getId()).isEqualTo(blueprint.getId());
         assertThat(persisted.getPermanent()).isTrue();
         assertThat(persisted.getSlotsRequired()).isEqualTo(6);
+        assertThat(created.getSlotsRequired()).isEqualTo(6);
         assertThat(persisted.getContainerImage()).isEqualTo("ghcr.io/spookly/hytale:override");
         assertThat(persisted.getInstallScript()).isEqualTo("echo install override");
         assertThat(objectMapper.readValue(persisted.getStartCommandJson(), new TypeReference<List<String>>() {

--- a/backend/brain/src/test/java/net/spookly/kodama/brain/service/SchedulingServiceTest.java
+++ b/backend/brain/src/test/java/net/spookly/kodama/brain/service/SchedulingServiceTest.java
@@ -24,7 +24,8 @@ class SchedulingServiceTest {
                 List.of(offline, full, available),
                 null,
                 null,
-                null
+                null,
+                1
         );
 
         assertThat(selected).isEqualTo(available);
@@ -39,7 +40,8 @@ class SchedulingServiceTest {
                 List.of(euNode, usNode),
                 "us-east-1",
                 null,
-                null
+                null,
+                1
         );
 
         assertThat(selected).isEqualTo(usNode);
@@ -54,7 +56,8 @@ class SchedulingServiceTest {
                 List.of(withTags, missingTag),
                 null,
                 "primary, ssd",
-                null
+                null,
+                1
         );
 
         assertThat(selected).isEqualTo(withTags);
@@ -69,14 +72,16 @@ class SchedulingServiceTest {
                 List.of(devNode, prodNode),
                 null,
                 null,
-                true
+                true,
+                1
         );
 
         Node prodSelected = schedulingService.selectNodeFromCandidates(
                 List.of(devNode, prodNode),
                 null,
                 null,
-                false
+                false,
+                1
         );
 
         assertThat(devSelected).isEqualTo(devNode);
@@ -92,7 +97,8 @@ class SchedulingServiceTest {
                 List.of(busy, idle),
                 null,
                 null,
-                null
+                null,
+                1
         );
 
         assertThat(selected).isEqualTo(idle);
@@ -107,7 +113,8 @@ class SchedulingServiceTest {
                 List.of(later, earlier),
                 null,
                 null,
-                null
+                null,
+                1
         );
 
         assertThat(selected).isEqualTo(earlier);
@@ -122,10 +129,51 @@ class SchedulingServiceTest {
                 List.of(offline, full),
                 null,
                 null,
-                null
+                null,
+                1
         );
 
         assertThat(selected).isNull();
+    }
+
+    @Test
+    void selectNodeRequiresAggregateCapacityForRequestedSlots() {
+        Node lowerUsedButTooSmall = buildNode("node-a", "eu-west-1", NodeStatus.ONLINE, false, 4, 3, null);
+        Node eligible = buildNode("node-b", "eu-west-1", NodeStatus.ONLINE, false, 6, 4, null);
+
+        Node selected = schedulingService.selectNodeFromCandidates(
+                List.of(lowerUsedButTooSmall, eligible),
+                null,
+                null,
+                null,
+                2
+        );
+
+        assertThat(selected).isEqualTo(eligible);
+    }
+
+    @Test
+    void selectNodeReturnsNullWhenOnlyCapacityIsInsufficient() {
+        Node first = buildNode("node-a", "eu-west-1", NodeStatus.ONLINE, false, 4, 3, "primary");
+        Node second = buildNode("node-b", "eu-west-1", NodeStatus.ONLINE, false, 8, 7, "primary");
+
+        Node selected = schedulingService.selectNodeFromCandidates(
+                List.of(first, second),
+                "eu-west-1",
+                "primary",
+                false,
+                2
+        );
+
+        boolean hasEligibleByFilters = schedulingService.hasEligibleNodesFromCandidates(
+                List.of(first, second),
+                "eu-west-1",
+                "primary",
+                false
+        );
+
+        assertThat(selected).isNull();
+        assertThat(hasEligibleByFilters).isTrue();
     }
 
     private Node buildNode(

--- a/contracts/openapi.yml
+++ b/contracts/openapi.yml
@@ -1654,6 +1654,12 @@ components:
           type: boolean
           nullable: true
           description: Optional node preference; when false, dev-mode nodes are excluded.
+        slotsRequired:
+          type: integer
+          format: int32
+          minimum: 1
+          nullable: true
+          description: Effective slot reservation for this instance. Defaults to 1 for new instances.
         portsJson:
           type: string
           nullable: true

--- a/docs/brain/scheduling-service.md
+++ b/docs/brain/scheduling-service.md
@@ -8,7 +8,7 @@ Selection rules:
 - If a region is provided, only consider nodes in that region.
 - If tags are provided, the node must contain all requested tags.
 - If `devModeAllowed` is provided, the node's `devMode` must match it.
-- Nodes must have `usedSlots < capacitySlots`.
+- Nodes must satisfy `usedSlots + slotsRequired <= capacitySlots`.
 - Choose the node with the lowest `usedSlots`, then by name, then by id.
 
 Tag format:
@@ -19,4 +19,6 @@ Tag format:
 Implementation:
 - `brain/src/main/java/net/spookly/kodama/brain/service/SchedulingService.java`
 - Returns a `Node` or `null` if no candidate is available.
-- If no candidate is available during instance creation, the request fails with `409 Conflict`.
+- If no node matches filters, instance creation fails with `409 Conflict` and `No eligible nodes found`.
+- If nodes match filters but lack capacity for `slotsRequired`, instance creation fails with
+  `409 Conflict` and an insufficient capacity message.


### PR DESCRIPTION
## Description
- Added validation to ensure sufficient node capacity for requested `slotsRequired` in both selected and provided nodes.
- Updated scheduling logic to account for aggregate `slotsRequired` when filtering eligible nodes.
- Made `slotsRequired` explicitly configurable in instance requests, with a default fallback to 1.
- Enhanced OpenAPI contracts, DTOs, and documentation to reflect `slotsRequired` changes.
- Improved test coverage for scheduling and capacity validation scenarios.

## Linked Issues
Closes #157

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
