### PR TITLE
feat(#158): extend instance registry with runtime fields, legacy support, and defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ out/
 # Editor-based Rest Client
 .idea/httpRequests
 /.gradle-local/**
+
+.env

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryEntry.java
@@ -5,13 +5,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import net.spookly.kodama.nodeagent.instance.dto.NodePrepareInstanceLayer;
 
 public record InstanceRegistryEntry(
         UUID instanceId,
         String name,
         String displayName,
+        String containerImage,
+        String installScript,
+        List<String> startCommand,
+        Integer slotsRequired,
+        @JsonAlias("allocatedPorts")
         String portsJson,
+        boolean installCompleted,
         Map<String, String> variables,
         List<NodePrepareInstanceLayer> layers,
         OffsetDateTime preparedAt,
@@ -22,4 +29,46 @@ public record InstanceRegistryEntry(
         String containerExitReason,
         String workspacePath
 ) {
+
+    public InstanceRegistryEntry {
+        startCommand = startCommand == null ? List.of() : startCommand;
+        slotsRequired = slotsRequired == null ? 1 : slotsRequired;
+    }
+
+    public InstanceRegistryEntry(
+            UUID instanceId,
+            String name,
+            String displayName,
+            String portsJson,
+            Map<String, String> variables,
+            List<NodePrepareInstanceLayer> layers,
+            OffsetDateTime preparedAt,
+            String containerId,
+            String containerStatus,
+            OffsetDateTime containerStatusUpdatedAt,
+            Integer containerExitCode,
+            String containerExitReason,
+            String workspacePath
+    ) {
+        this(
+                instanceId,
+                name,
+                displayName,
+                null,
+                null,
+                List.of(),
+                1,
+                portsJson,
+                false,
+                variables,
+                layers,
+                preparedAt,
+                containerId,
+                containerStatus,
+                containerStatusUpdatedAt,
+                containerExitCode,
+                containerExitReason,
+                workspacePath
+        );
+    }
 }

--- a/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
+++ b/backend/node-agent/src/main/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryService.java
@@ -54,6 +54,9 @@ public class InstanceRegistryService {
         requireMatchingInstanceId(instanceId, workspace.instanceId());
         List<NodePrepareInstanceLayer> safeLayers = requireLayers(layers);
         Map<String, String> safeVariables = variables == null ? Map.of() : new LinkedHashMap<>(variables);
+        List<String> safeStartCommand = request.startCommand() == null
+                ? List.of()
+                : new ArrayList<>(request.startCommand());
         Path instanceRoot = Objects.requireNonNull(workspace.instanceRoot(), "instanceRoot");
         if (!Files.isDirectory(instanceRoot)) {
             throw new InstanceRegistryException("Instance workspace root is missing at " + instanceRoot);
@@ -63,7 +66,12 @@ public class InstanceRegistryService {
                 instanceId,
                 request.name(),
                 request.displayName(),
+                request.containerImage(),
+                request.installScript(),
+                safeStartCommand,
+                request.slotsRequired(),
                 request.portsJson(),
+                false,
                 safeVariables,
                 new ArrayList<>(safeLayers),
                 OffsetDateTime.now(),
@@ -128,7 +136,12 @@ public class InstanceRegistryService {
                 entry.instanceId(),
                 entry.name(),
                 entry.displayName(),
+                entry.containerImage(),
+                entry.installScript(),
+                entry.startCommand(),
+                entry.slotsRequired(),
                 entry.portsJson(),
+                entry.installCompleted(),
                 entry.variables(),
                 entry.layers(),
                 entry.preparedAt(),
@@ -179,7 +192,12 @@ public class InstanceRegistryService {
                 entry.instanceId(),
                 entry.name(),
                 entry.displayName(),
+                entry.containerImage(),
+                entry.installScript(),
+                entry.startCommand(),
+                entry.slotsRequired(),
                 entry.portsJson(),
+                entry.installCompleted(),
                 entry.variables(),
                 entry.layers(),
                 entry.preparedAt(),
@@ -342,7 +360,12 @@ public class InstanceRegistryService {
                 entry.instanceId(),
                 entry.name(),
                 entry.displayName(),
+                entry.containerImage(),
+                entry.installScript(),
+                entry.startCommand(),
+                entry.slotsRequired(),
                 entry.portsJson(),
+                entry.installCompleted(),
                 null,
                 entry.layers(),
                 entry.preparedAt(),
@@ -392,7 +415,12 @@ public class InstanceRegistryService {
                 entry.instanceId(),
                 entry.name(),
                 entry.displayName(),
+                entry.containerImage(),
+                entry.installScript(),
+                entry.startCommand(),
+                entry.slotsRequired(),
                 entry.portsJson(),
+                entry.installCompleted(),
                 entry.variables(),
                 entry.layers(),
                 entry.preparedAt(),

--- a/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
+++ b/backend/node-agent/src/test/java/net/spookly/kodama/nodeagent/instance/registry/InstanceRegistryServiceTest.java
@@ -3,6 +3,7 @@ package net.spookly.kodama.nodeagent.instance.registry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,11 @@ class InstanceRegistryServiceTest {
                 instanceId,
                 "instance-name",
                 "Instance Name",
+                "ghcr.io/spookly/hytale:test",
+                "./install.sh",
+                List.of("java", "-jar", "server.jar"),
+                2,
+                null,
                 "{\"port\":25565}",
                 variables,
                 null,
@@ -61,7 +67,12 @@ class InstanceRegistryServiceTest {
         assertThat(entry.instanceId()).isEqualTo(instanceId);
         assertThat(entry.name()).isEqualTo("instance-name");
         assertThat(entry.displayName()).isEqualTo("Instance Name");
+        assertThat(entry.containerImage()).isEqualTo("ghcr.io/spookly/hytale:test");
+        assertThat(entry.installScript()).isEqualTo("./install.sh");
+        assertThat(entry.startCommand()).containsExactly("java", "-jar", "server.jar");
+        assertThat(entry.slotsRequired()).isEqualTo(2);
         assertThat(entry.portsJson()).isEqualTo("{\"port\":25565}");
+        assertThat(entry.installCompleted()).isFalse();
         assertThat(entry.variables()).containsEntry("REGION", "local");
         assertThat(entry.layers()).hasSize(1);
         assertThat(entry.layers().get(0).templateId()).isEqualTo(layer.templateId());
@@ -90,6 +101,11 @@ class InstanceRegistryServiceTest {
         NodePrepareInstanceRequest request = new NodePrepareInstanceRequest(
                 instanceId,
                 "instance-name",
+                "Instance Name",
+                "ghcr.io/spookly/hytale:test",
+                "./install.sh",
+                List.of("java", "-jar", "server.jar"),
+                2,
                 null,
                 null,
                 Map.of(),
@@ -121,6 +137,11 @@ class InstanceRegistryServiceTest {
         NodePrepareInstanceRequest request = new NodePrepareInstanceRequest(
                 instanceId,
                 "instance-name",
+                "Instance Name",
+                "ghcr.io/spookly/hytale:test",
+                "./install.sh",
+                List.of("java", "-jar", "server.jar"),
+                2,
                 null,
                 null,
                 Map.of(),
@@ -136,6 +157,11 @@ class InstanceRegistryServiceTest {
 
         Path registryFile = workspace.instanceRoot().resolve("instance.json");
         InstanceRegistryEntry entry = objectMapper().readValue(registryFile.toFile(), InstanceRegistryEntry.class);
+        assertThat(entry.containerImage()).isEqualTo("ghcr.io/spookly/hytale:test");
+        assertThat(entry.installScript()).isEqualTo("./install.sh");
+        assertThat(entry.startCommand()).containsExactly("java", "-jar", "server.jar");
+        assertThat(entry.slotsRequired()).isEqualTo(2);
+        assertThat(entry.installCompleted()).isFalse();
         assertThat(entry.containerId()).isEqualTo("container-123");
         assertThat(entry.containerStatus()).isEqualTo("running");
         assertThat(entry.containerStatusUpdatedAt()).isNotNull();
@@ -160,6 +186,11 @@ class InstanceRegistryServiceTest {
         NodePrepareInstanceRequest request = new NodePrepareInstanceRequest(
                 instanceId,
                 "instance-name",
+                "Instance Name",
+                "ghcr.io/spookly/hytale:test",
+                "./install.sh",
+                List.of("java", "-jar", "server.jar"),
+                2,
                 null,
                 null,
                 Map.of(),
@@ -176,6 +207,11 @@ class InstanceRegistryServiceTest {
 
         Path registryFile = workspace.instanceRoot().resolve("instance.json");
         InstanceRegistryEntry entry = objectMapper().readValue(registryFile.toFile(), InstanceRegistryEntry.class);
+        assertThat(entry.containerImage()).isEqualTo("ghcr.io/spookly/hytale:test");
+        assertThat(entry.installScript()).isEqualTo("./install.sh");
+        assertThat(entry.startCommand()).containsExactly("java", "-jar", "server.jar");
+        assertThat(entry.slotsRequired()).isEqualTo(2);
+        assertThat(entry.installCompleted()).isFalse();
         assertThat(entry.containerId()).isEqualTo("container-123");
         assertThat(entry.containerStatus()).isEqualTo("stopped");
         assertThat(entry.containerStatusUpdatedAt()).isNotNull();
@@ -238,6 +274,68 @@ class InstanceRegistryServiceTest {
         assertThat(entries)
                 .anyMatch(entry -> entry.workspacePath().equals(Path.of("instances", firstId.toString()).toString()))
                 .anyMatch(entry -> entry.workspacePath().equals(Path.of("instances", secondId.toString()).toString()));
+    }
+
+    @Test
+    void loadRegistryDefaultsMissingBlueprintRuntimeFieldsForLegacyEntries() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, instanceId.toString());
+        Path registryFile = workspace.instanceRoot().resolve("instance.json");
+        String legacyJson = """
+                {
+                  "instanceId": "%s",
+                  "name": "legacy",
+                  "displayName": "Legacy",
+                  "portsJson": "{\\"game\\":25565}",
+                  "variables": {
+                    "ENV": "prod"
+                  },
+                  "layers": [],
+                  "preparedAt": null,
+                  "containerId": null,
+                  "containerStatus": null,
+                  "containerStatusUpdatedAt": null,
+                  "containerExitCode": null,
+                  "containerExitReason": null,
+                  "workspacePath": null
+                }
+                """.formatted(instanceId);
+        Files.writeString(registryFile, legacyJson);
+
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
+        InstanceRegistryEntry entry = registryService.loadRegistry(workspace);
+
+        assertThat(entry.containerImage()).isNull();
+        assertThat(entry.installScript()).isNull();
+        assertThat(entry.startCommand()).isEmpty();
+        assertThat(entry.slotsRequired()).isEqualTo(1);
+        assertThat(entry.installCompleted()).isFalse();
+    }
+
+    @Test
+    void loadRegistrySupportsAllocatedPortsAlias() throws Exception {
+        UUID instanceId = UUID.randomUUID();
+        InstanceWorkspaceLayout layout = workspaceLayout();
+        InstanceWorkspacePaths workspace = prepareWorkspace(layout, instanceId.toString());
+        Path registryFile = workspace.instanceRoot().resolve("instance.json");
+        String aliasJson = """
+                {
+                  "instanceId": "%s",
+                  "name": "legacy",
+                  "displayName": "Legacy",
+                  "allocatedPorts": "{\\"game\\":25565}",
+                  "variables": {},
+                  "layers": [],
+                  "workspacePath": null
+                }
+                """.formatted(instanceId);
+        Files.writeString(registryFile, aliasJson);
+
+        InstanceRegistryService registryService = new InstanceRegistryService(objectMapper(), layout);
+        InstanceRegistryEntry entry = registryService.loadRegistry(workspace);
+
+        assertThat(entry.portsJson()).isEqualTo("{\"game\":25565}");
     }
 
     private InstanceWorkspacePaths prepareWorkspace(InstanceWorkspaceLayout layout, String instanceId) {

--- a/contracts/nodeapi.yml
+++ b/contracts/nodeapi.yml
@@ -132,7 +132,12 @@ endpoints:
         - instanceId: uuid
           name: string|null
           displayName: string|null
+          containerImage: string|null
+          installScript: string|null
+          startCommand: list<string>
+          slotsRequired: int32
           portsJson: string|null
+          installCompleted: boolean
           variables: map<string,string>|null (redacted in registry listing)
           layers:
             - templateVersionId: uuid

--- a/docs/node/operations/instance-registry.md
+++ b/docs/node/operations/instance-registry.md
@@ -14,7 +14,9 @@ Persist a local record of instance metadata after the node finishes preparing a 
 - Location: `${NODE_AGENT_WORKSPACE_DIR:-./data}/instances/<instanceId>/instance.json`.
 - Contents include:
   - instance id, name, display name
+  - resolved runtime fields: `containerImage`, `installScript`, `startCommand`, `slotsRequired`
   - ports JSON (if provided)
+  - install completion status (`installCompleted`)
   - resolved variables map used for substitution
   - template layer list from the prepare request
   - prepared timestamp
@@ -22,6 +24,11 @@ Persist a local record of instance metadata after the node finishes preparing a 
   - container status and status timestamp (updated on start/stop/monitor)
   - container exit code and exit reason (recorded when containers stop)
 - The registry is overwritten on each successful prepare and updated again when the container id is recorded.
+- Legacy registry files that predate runtime fields are still readable; missing runtime fields default to:
+  - `startCommand: []`
+  - `slotsRequired: 1`
+  - `installCompleted: false`
+  - nullable runtime strings remain `null`
 - Container status updates are recorded when start marks the instance as `running` and stop marks it as `stopped`.
 - The instance monitor polls tracked containers (including stopped ones) and reconciles status changes,
   so manual restarts are reflected in the registry.


### PR DESCRIPTION
## Description
- Added `containerImage`, `installScript`, `startCommand`, `slotsRequired`, and `installCompleted` to instance registry.
- Updated `InstanceRegistryService` to load missing runtime fields for legacy registry files with defaults.
- Enhanced related DTOs, OpenAPI contracts, and documentation.
- Added tests for new fields and legacy registry compatibility.

## Linked Issues
Closes #158

## Checklist
- [ ] Code is complete
- [ ] Tests updated if needed
- [ ] No unrelated changes
- [ ] Ready for review
